### PR TITLE
Docs update

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ be found [here](https://cecill.info/).
 ## Dependencies
 The library may be built on Unix-like operating systems or on Windows. All that
 is required is cmake >= 3.11, and a C++ compiler which supports the C++20
-standard. For Unix-like systems, the recommended compilers are GCC >= 11.2.
+standard. For Unix-like systems, the recommended compilers are GCC >= 11.
 On Windows, you should have MSVC >= 19.29. In order to build the
 Python interface, Python >= 3.5 should be installed on your system, in
 addition to the Python development libraries and header files.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,7 +11,7 @@ used to read continuous energy ACE files, for neutron cross sections and
 secondary distributions. It can find and evaluate cross sections, sample
 secondary angle and energy distributions, and provide access to much more data.
 
-Written in C++17 with object orientation, the library provides an easy way to
+Written in C++20 with object orientation, the library provides an easy way to
 get the data you need out of ACE files, and fast. A Python API is also generated
 using Pybind11, allowing you the same speedy access through Python, without
 having to learn a second API! This is a great option for when you want to

--- a/docs/install/index.rst
+++ b/docs/install/index.rst
@@ -10,22 +10,13 @@ Build Requirements
 
 To build the C++ library on linux, a C++ compiler is required, which supports
 the C++20 standard. On Linux systems, the only current option which satisfied
-this is GCC 11.2. On Windows, you will need MSVC >= 19.29. You will also need
+this is GCC >= 11. On Windows, you will need MSVC >= 19.29. You will also need
 cmake >= 3.11, whether you use Windows or linux.
 
 In addition, if you would like to build the Python API, you will also need to
 ensure that the Python development headers are installed on your system.
 
-Debian / Ubuntu / LinuxMint
----------------------------
-To ensure you have all the build requirements on a Debian based system, run the
-following command:
-
-.. code-block:: sh
-
-  sudo apt install g++ cmake python3-dev
-
-Fedora / CentOS / RedHat
+Fedora 35+
 ------------------------
 To ensure you have all the build requirements on a RedHat based system, run the
 following command:
@@ -34,7 +25,7 @@ following command:
 
   sudo dnf install g++ cmake python3-devel
 
-Arch / Manjaro
+Arch / Manjaro 21+
 ------------------------
 To ensure you have all the build requirements on an Arch based system, run the
 following command:
@@ -43,12 +34,24 @@ following command:
 
   sudo pacman -S g++ cmake python3
 
+Other Linux Distributions
+-------------------------
+Unfortunately, GCC-11 is quite new, and many distrubtions do not yet ship this
+compiler toolchain, or have specific installation commands. If you are not
+using one of hte distributions listed above, first check to see if there is
+a specific method to install GCC-11 form your distributions repositories. If
+not, I recommend building GCC-11 from source. This is outside the scope of these
+installation instruction, but instructions are readily found online.
+
 Windows
 --------
 There are no quick and easy commands to install the necessary dependencies on
 Windows sadly. You should insall Visual Studio 2019, and when performing the
 installation, be sure to also install the Python development libraries. You
-will also have to download and install cmake separately as well.
+will also have to download and install cmake separately as well. If you already
+have Visual Studio 2019 installed, you should make sure that it has been
+updated to the most recent version, or that the compiler version is at least
+MSVC >= 19.29.
 
 ------------------
 Getting the Source
@@ -106,6 +109,15 @@ PNDL_PYTHON
 
 PNDL_TESTS
   This is used to build the unit tests, and is turned off by default.
+
+PNDL_SHARED
+  Builds a shared library, as opposed to a static library. This is turned on by
+  default. When building on Windows, this will automatically be turned off.
+
+PNDL_INSTALL
+  Adds and exports the installation targets for PapillonNDL. This is truned on
+  by default, but can be turned off if using PapillonNDL as a build dependency
+  in another project.
 
 Several other standard cmake options will also be usefull in many cases, and
 are therefore listed here:

--- a/docs/install/index.rst
+++ b/docs/install/index.rst
@@ -16,7 +16,7 @@ cmake >= 3.11, whether you use Windows or linux.
 In addition, if you would like to build the Python API, you will also need to
 ensure that the Python development headers are installed on your system.
 
-Fedora 35+
+Fedora 34+
 ------------------------
 To ensure you have all the build requirements on a RedHat based system, run the
 following command:


### PR DESCRIPTION
This PR updates the installation documentation to reflect the new build requirements and closes #4 . As GCC-11 isn't readily available in all distributions. Because of this, the build requirements instructions have been reduced to only include Fedora 34 and Arch / Manjaro, which currently provide GCC-11. Users of other distros are instructed to search for specific instructions for their distro, or build GCC-11 from source. This is only temporary though, while compilers still work on C++20 support.