### PR TITLE
Adds new classes to identify elements, isotopes, and nuclides

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ project(PapillonNDL
 )
 
 include(CMakePackageConfigHelpers)
+include(FetchContent)
 
 # Add options
 option(PNDL_SHARED "Build PapillonNDL as a shared library" ON)
@@ -15,7 +16,8 @@ option(PNDL_INSTALL "Install the PapillonNDL library and header files" ON)
 option(PNDL_TESTS "Build PapillonNDL tests" OFF)
 
 # List of source files for PapillonNDL
-set(PNDL_SOURCE_LIST src/region_1d.cpp
+set(PNDL_SOURCE_LIST src/element.cpp
+                     src/region_1d.cpp
                      src/multi_region_1d.cpp
                      src/polynomial_1d.cpp
                      src/ace.cpp
@@ -84,6 +86,7 @@ target_include_directories(PapillonNDL PUBLIC
 # Require C++20 standard
 target_compile_features(PapillonNDL PUBLIC cxx_std_20)
 
+
 if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC") # Comile options for Windows
   target_compile_options(PapillonNDL PRIVATE /W4)
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU") # Compile options for GCC
@@ -114,14 +117,10 @@ if(PNDL_PYTHON)
   if(NOT pybind11_FOUND)
     message(STATUS "Could not find a local install of Pybind11")
     message(STATUS "Will download Pybind11 instead")
-
-    include(FetchContent)
-
     FetchContent_Declare(pybind11
       GIT_REPOSITORY https://github.com/pybind/pybind11
       GIT_TAG        v2.9.1
     )
-
     FetchContent_MakeAvailable(pybind11)
   else()
     message(STATUS "Using local install of Pybind11")
@@ -146,6 +145,7 @@ if(PNDL_PYTHON)
                                     src/python/delayed_group.cpp
                                     src/python/ce_neutron.cpp
                                     src/python/prng.cpp
+                                    src/python/nuclide.cpp
   )
   
   # Require C++20 standard

--- a/include/PapillonNDL/element.hpp
+++ b/include/PapillonNDL/element.hpp
@@ -1,0 +1,143 @@
+/*
+ * Papillon Nuclear Data Library
+ * Copyright 2021, Hunter Belanger
+ *
+ * hunter.belanger@gmail.com
+ *
+ * This file is part of the Papillon Nuclear Data Library (PapillonNDL).
+ *
+ * PapillonNDL is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PapillonNDL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PapillonNDL. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * */
+#ifndef PAPILLON_NDL_ELEMENT_H
+#define PAPILLON_NDL_ELEMENT_H
+
+/**
+ * @file
+ * @author Hunter Belanger
+ */
+
+#include <PapillonNDL/zaid.hpp>
+#include <PapillonNDL/pndl_exception.hpp>
+
+#include <array>
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <ostream>
+
+namespace pndl {
+
+/**
+ * @brief Class which identifies an element.
+ */
+class Element {
+  public:
+    /**
+     * @param Z Atomic number of the element. Must be in the interval [1,118].
+     */
+    Element(uint8_t Z): Z_(Z) {
+      if (Z_ == 0 || Z_ > N_ELEM) {
+        std::string mssg = "Elements must have an atomic number "
+                           "in interval [1," + std::to_string(N_ELEM) + "].";
+        throw PNDLException(mssg); 
+      }
+    }
+
+    /**
+     * @brief Returns the atomic number of the element.
+     */
+    uint8_t Z() const { return Z_; }
+
+    /**
+     * @brief Returns the atomic number of the element.
+     */
+    uint8_t atomic_number() const { return Z_; }
+
+    
+    /**
+     * @brief Returns the symbol of the element.
+     */
+    const std::string& symbol() const {
+      return elements_table[static_cast<std::size_t>(Z_-1)].symbol;
+    }
+    
+    /**
+     * @brief Returns the name of the element.
+     */
+    const std::string& name() const {
+      return elements_table[static_cast<std::size_t>(Z_-1)].name;
+    }
+
+    /**
+     * @brief Returns the ZAID which represents the natural element.
+     */
+    ZAID zaid() const { return ZAID(Z_, 0); }
+    
+    /**
+     * @brief Returns true if two elements are the same, and false if not.
+     */
+    bool operator==(const Element& rhs) const {
+      return this->Z_ == rhs.Z_; 
+    }
+    
+    /**
+     * @brief Returns true if the Element's atomic number is less than the
+     *        other's, and false if otherwise.
+     */
+    bool operator<(const Element& rhs) const {
+      return this->Z_ < rhs.Z_; 
+    }
+    
+    /**
+     * @brief Finds an element from a symbol.
+     * @param symbol String which holds the element symbol for which to search.
+     */
+    static Element from_symbol(const std::string& symbol);
+  
+    /**
+     * @brief Finds an element from a name.
+     * @param symbol String which holds the element name for which to search.
+     */
+    static Element from_name(const std::string& name);
+
+  private:
+    struct Info {
+      std::string name; 
+      std::string symbol;
+    };
+    static constexpr uint8_t N_ELEM {118};
+
+    uint8_t Z_;
+
+    static std::array<Info,N_ELEM> elements_table;
+};
+
+inline
+std::ostream& operator<<(std::ostream& strm, const Element& elem) {
+  strm << elem.symbol();
+  return strm;
+}
+
+}
+
+template<>
+struct std::hash<pndl::Element> {
+  std::size_t operator()(const pndl::Element& elem) const noexcept {
+    std::hash<uint8_t> h;
+    return h(elem.Z()); 
+  }
+};
+
+#endif

--- a/include/PapillonNDL/isotope.hpp
+++ b/include/PapillonNDL/isotope.hpp
@@ -1,0 +1,175 @@
+/*
+ * Papillon Nuclear Data Library
+ * Copyright 2021, Hunter Belanger
+ *
+ * hunter.belanger@gmail.com
+ *
+ * This file is part of the Papillon Nuclear Data Library (PapillonNDL).
+ *
+ * PapillonNDL is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PapillonNDL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PapillonNDL. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * */
+#ifndef PAPILLON_NDL_ISOTOPE_H
+#define PAPILLON_NDL_ISOTOPE_H
+
+/**
+ * @file
+ * @author Hunter Belanger
+ */
+
+#include <PapillonNDL/element.hpp>
+#include <PapillonNDL/pndl_exception.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <ostream>
+
+namespace pndl {
+
+/**
+ * @brief Class which identifies an isotope.
+ */
+class Isotope {
+  public:
+    /**
+     * @param element Element of the Isotope.
+     * @param A Atomic mass of the Isotope.
+     */
+    Isotope(const Element& element, uint32_t A): element_(element), A_(A) {
+      if (A < element_.Z()) {
+        std::string mssg = "Cannot create isotope " + element_.name() +
+          std::to_string(this->A()) + ". Isotopes must satisfy A >= Z." +
+          "Was provided with A = " + std::to_string(this->A()) + ", Z = " +
+          std::to_string(this->Z()) + ".";
+        throw PNDLException(mssg); 
+      }
+
+      if (A >= 300) {
+        std::string mssg = "Cannot create isotope " + element_.name() +
+          std::to_string(this->A()) + ". Isotopes must satisfy A < 300." +
+          "Was provided with A = " + std::to_string(this->A()) + ".";
+        throw PNDLException(mssg); 
+
+      }
+    }
+
+    /**
+     * @param Z Atomic number of the Isotope.
+     * @param A Atomic mass of the Isotope.
+     */
+    Isotope(uint8_t Z, uint32_t A): element_(1), A_(A) {
+      try {
+        element_ = Element(Z); 
+      } catch (PNDLException& err) {
+        std::string mssg = "Could not construct Element associated with Isotope.";
+        err.add_to_exception(mssg); 
+        throw err;
+      }
+
+      if (A >= 300) {
+        std::string mssg = "Cannot create isotope " + element_.name() +
+          std::to_string(this->A()) + ". Isotopes must satisfy A < 300." +
+          "Was provided with A = " + std::to_string(this->A()) + ".";
+        throw PNDLException(mssg); 
+
+      }
+    }
+    
+    /**
+     * @brief Returns atomic number of isotope.
+     */ 
+    uint8_t Z() const { return element_.Z(); }
+    
+    /**
+     * @brief Returns atomic number of isotope.
+     */ 
+    uint8_t atomic_number() const { return Z(); }
+    
+    /**
+     * @brief Returns atomic mass of isotope.
+     */
+    uint32_t A() const { return A_; }
+    
+    /**
+     * @brief Returns atomic mass of isotope.
+     */
+    uint32_t atomic_mass() const { return A(); }
+    
+    /**
+     * @bried Returns ZAID of isotope.
+     */ 
+    ZAID zaid() const { return ZAID(element_.Z(), A_); }
+  
+    /** 
+     * @brief Returns the symbol of the isotope.
+     */
+    std::string symbol() const { return element_.symbol() + std::to_string(A_); }
+    
+    /**
+     * @brief Returns the Element symbol of the isotope.
+     */
+    const std::string& element_symbol() const { return element_.symbol(); }
+    
+    /**
+     * @brief Returns the Element name of the isotope.
+     */
+    const std::string& element_name() const { return element_.name(); }
+    
+    /**
+     * @brief Returns true if two isotopes are the same, and false if not.
+     */
+    bool operator==(const Isotope& rhs) const {
+      if (Z() == rhs.Z() && A() == rhs.A()) return true;
+      return false;
+    }
+    
+    /**
+     * @brief Returns true if one Isotope's atomic number is less than the
+     *        other's. If the atomic numbers are equal and the Isotope's atomic
+     *        mass is less than the other's, true is also returned. Otherwise,
+     *        flase is returned.
+     */
+    bool operator<(const Isotope& rhs) const {
+      if (Z() < rhs.Z()) return true; 
+      else if (Z() > rhs.Z()) return false;
+      
+      if (A() < rhs.A()) return true;
+      
+      return false;
+    }
+
+  private:
+    Element element_;
+    uint32_t A_;
+};
+
+inline
+std::ostream& operator<<(std::ostream& strm, const Isotope& istp) {
+  strm << istp.element_symbol() << istp.A();
+  return strm;
+}
+
+}
+
+template<>
+struct std::hash<pndl::Isotope> {
+  std::size_t operator()(const pndl::Isotope& iso) const noexcept {
+    std::hash<uint32_t> h;
+    return h(iso.Z()*1000 + iso.A());  
+  }
+};
+
+#endif

--- a/include/PapillonNDL/nuclide.hpp
+++ b/include/PapillonNDL/nuclide.hpp
@@ -1,0 +1,203 @@
+/*
+ * Papillon Nuclear Data Library
+ * Copyright 2021, Hunter Belanger
+ *
+ * hunter.belanger@gmail.com
+ *
+ * This file is part of the Papillon Nuclear Data Library (PapillonNDL).
+ *
+ * PapillonNDL is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PapillonNDL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PapillonNDL. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * */
+#ifndef PAPILLON_NDL_NUCLIDE_H
+#define PAPILLON_NDL_NUCLIDE_H
+
+/**
+ * @file
+ * @author Hunter Belanger
+ */
+
+#include <PapillonNDL/isotope.hpp>
+#include <PapillonNDL/zaid.hpp>
+#include <PapillonNDL/pndl_exception.hpp>
+
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <ostream>
+
+namespace pndl {
+
+/**
+ * @brief Class which identifies a nuclide.
+ */
+class Nuclide {
+  public:
+    /**
+     * @param isotope Isotope of the nuclide.
+     * @param level Isomer level of the nuclide.
+     */
+    Nuclide(const Isotope& isotope, uint8_t level = 0): isotope_(isotope), level_(level) {
+      if (level > 5) {
+        std::string mssg = "Cannot create Nuclide with iosmer lever greater than 5. "
+          "Was provided with level = " + std::to_string(level_) + ".";
+        throw  PNDLException(mssg);
+      }
+    }
+    
+    /**
+     * @param Z Atomic number of nuclide.
+     * @param A Atomic mass of nuclide.
+     * @param level Isomer level of nuclide.
+     */
+    Nuclide(uint8_t Z, uint32_t A, uint8_t level=0): isotope_(1,1), level_(level) {
+      try {
+        isotope_ = Isotope(Z,A); 
+      } catch (PNDLException& err) {
+        std::string mssg = "Could not create isotope.";
+        err.add_to_exception(mssg);
+        throw err;
+      }
+
+      if (level > 5) {
+        std::string mssg = "Cannot create Nuclide with iosmer lever greater than 5. "
+          "Was provided with level = " + std::to_string(level_) + ".";
+        throw  PNDLException(mssg);
+      }
+    }
+    
+    /**
+     * @brief Returns atomic number of isotope.
+     */
+    uint8_t Z() const {
+      return isotope_.Z(); 
+    }
+    
+    /**
+     * @brief Returns atomic number of isotope.
+     */
+    uint8_t atomic_number() const {
+      return this->Z(); 
+    }
+    
+    /**
+     * @brief Returns atomic mass of isotope.
+     */
+    uint32_t A() const {
+      return isotope_.A(); 
+    }
+    
+    /**
+     * @brief Returns atomic mass of isotope.
+     */
+    uint32_t atomic_mass() const {
+      return this->A(); 
+    }
+    
+    /**
+     * @brief Returns the isomer level of the nuclide.
+     */
+    uint8_t level() const {
+      return level_; 
+    }
+    
+    /**
+     * @brief Returns the ZAID for the nuclide.
+     */
+    ZAID zaid() const {
+      return ZAID(this->Z(), this->A() + 300*level_); 
+    }
+    
+    /**
+     * @brief Returns the symbol of the nuclide.
+     */
+    std::string symbol() const {
+      std::string symbl = isotope_.symbol(); 
+      if (level_ > 0) {
+        symbl += 'm';
+        symbl += std::to_string(level_); 
+      }
+      return symbl;
+    }
+    
+    /**
+     * @brief Returns the symbol of the isotope.
+     */
+    std::string isotope_symbol() const {
+      return isotope_.symbol(); 
+    }
+    
+    /**
+     * @brief Returns the element symbol of the nuclide.
+     */
+    const std::string& element_symbol() const {
+      return isotope_.element_symbol(); 
+    }
+
+    /**
+     * @brief Returns the element name of the nuclide.
+     */
+    const std::string& element_name() const {
+      return isotope_.element_name(); 
+    }
+    
+    /**
+     * @brief Returns true if two Nuclide are the same, and false if not.
+     */
+    bool operator==(const Nuclide& rhs) const {
+      if (Z() == rhs.Z() && A() == rhs.A() && level() == rhs.level())  return true;
+      return false; 
+    }
+    
+    /**
+     * @brief Returns true if one Nuclides's atomic number is less than the
+     *        other's. If the atomic numbers are equal and the Nuclides's atomic
+     *        mass is less than the other's, true is also returned. If the
+     *        atomic masses are equal, and the isomer level is less than the
+     *        other's, true is returned. Otherwise, flase is returned.
+     */
+    bool operator<(const Nuclide& rhs) const {
+      if (Z() < rhs.Z()) return true;
+      else if (Z() > rhs.Z()) return false;
+
+      if (A() < rhs.A()) return true;
+      else if (A() > rhs.A()) return false;
+
+      if (level() < rhs.level()) return true;
+
+      return false;
+    }
+
+  private:
+    Isotope isotope_;
+    uint8_t level_;
+};
+
+inline
+std::ostream& operator<<(std::ostream& strm, const Nuclide& nuc) {
+  strm << nuc.symbol();
+  return strm;
+}
+
+}
+
+template<>
+struct std::hash<pndl::Nuclide> {
+  std::size_t operator()(const pndl::Nuclide& nuc) const noexcept {
+    std::hash<uint32_t> h;
+    return h(nuc.Z()*1000 + nuc.A() + nuc.level()*300); 
+  }
+};
+
+#endif

--- a/include/PapillonNDL/zaid.hpp
+++ b/include/PapillonNDL/zaid.hpp
@@ -1,0 +1,106 @@
+/*
+ * Papillon Nuclear Data Library
+ * Copyright 2021, Hunter Belanger
+ *
+ * hunter.belanger@gmail.com
+ *
+ * This file is part of the Papillon Nuclear Data Library (PapillonNDL).
+ *
+ * PapillonNDL is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PapillonNDL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PapillonNDL. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * */
+#ifndef PAPILLON_NDL_ZAID_H
+#define PAPILLON_NDL_ZAID_H
+
+/**
+ * @file
+ * @author Hunter Belanger
+ */
+
+#include <cstdint>
+#include <functional>
+#include <ostream>
+
+namespace pndl {
+
+/**
+ * @brief Class which represents a ZAID identifier.
+ */
+class ZAID {
+  public:
+    /**
+     * @param Z Atomic number for ZAID.
+     * @param A Atomic mass for ZAID.
+     */
+    ZAID(uint8_t Z, uint32_t A): Z_(Z), A_(A) {}
+    
+    /**
+     * @brief Returns the atomic number of ZAID.
+     */
+    uint8_t Z() const { return Z_; }
+    
+    /**
+     * @brief Returns the atomic mass of ZAID.
+     */
+    uint32_t A() const { return A_; }
+    
+    /**
+     * @brief Returns the ZAID as an unsigned integer.
+     */
+    uint32_t zaid() const { return 1000*Z_ + A_; };
+    
+    /**
+     * @brief Returns true if two ZAIDs are equal, and false if not.
+     */
+    bool operator==(const ZAID& rhs) const {
+      return (this->Z_ == rhs.Z_) && (this->A_ == rhs.A_);
+    }
+    
+    /**
+     * @brief Returns true if one ZAID's atomic number is less than the
+     *        other's. If the atomic numbers are equal and the ZAID's atomic
+     *        mass is less than the other's, true is also returned. Otherwise,
+     *        flase is returned.
+     */
+    bool operator<(const ZAID& rhs) const {
+      if (Z() < rhs.Z()) return true; 
+      else if (Z() > rhs.Z()) return false;
+      
+      if (A() < rhs.A()) return true;
+      
+      return false;
+    }
+
+  private:
+    uint8_t Z_;
+    uint32_t A_; 
+};
+
+inline
+std::ostream& operator<<(std::ostream& strm, const ZAID& zaid) {
+  strm << zaid.Z() << zaid.A();
+  return strm;
+}
+
+}
+
+template<>
+struct std::hash<pndl::ZAID> {
+  std::size_t operator()(const pndl::ZAID& zaid) const noexcept {
+    std::hash<uint32_t> h;
+    return h(zaid.zaid());
+  }
+};
+
+#endif

--- a/src/element.cpp
+++ b/src/element.cpp
@@ -1,0 +1,134 @@
+/*
+ * Papillon Nuclear Data Library
+ * Copyright 2021, Hunter Belanger
+ *
+ * hunter.belanger@gmail.com
+ *
+ * This file is part of the Papillon Nuclear Data Library (PapillonNDL).
+ *
+ * PapillonNDL is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PapillonNDL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PapillonNDL. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * */
+
+#include <PapillonNDL/element.hpp>
+
+namespace pndl {
+
+Element Element::from_symbol(const std::string& symbol) {
+  uint8_t z = 0;
+  bool found = false;
+  for (z = 0; z < elements_table.size(); z++) {
+    if (elements_table[z].symbol == symbol) {
+      found = true;
+      break; 
+    } 
+  }
+  
+  // Make sure we found the element
+  if (found == false) {
+    std::string mssg = "Could not find an element with symbol \"" + symbol + "\"."; 
+    throw PNDLException(mssg);
+  }
+  
+  // Advance z by 1 for the correct atomic number.
+  z++;
+
+  return Element(z);
+}
+
+Element Element::from_name(const std::string& name) {
+  uint8_t z = 0;
+  bool found = false;
+  for (z = 0; z < elements_table.size(); z++) {
+    if (elements_table[z].name == name) {
+      found = true;
+      break; 
+    } 
+  }
+  
+  // Make sure we found the element
+  if (found == false) {
+    std::string mssg = "Could not find an element with name \"" + name + "\"."; 
+    throw PNDLException(mssg);
+  }
+  
+  // Advance z by 1 for the correct atomic number.
+  z++;
+
+  return Element(z);
+}
+
+std::array<Element::Info, Element::N_ELEM> Element::elements_table {
+  Element::Info {"Hydrogen", "H"},      Element::Info {"Helium", "He"},
+  Element::Info {"Lithium", "Li"},      Element::Info {"Beryllium", "Be"},
+  Element::Info {"Boron", "B"},         Element::Info {"Carbon", "C"},
+  Element::Info {"Nitrogen", "N"},      Element::Info {"Oxygen", "O"},
+  Element::Info {"Flourine", "F"},      Element::Info {"Neon", "Ne"},
+  Element::Info {"Sodium", "Na"},       Element::Info {"Magnesium", "Mg"},
+  Element::Info {"Aluminum", "Al"},     Element::Info {"Silicon", "Si"},
+  Element::Info {"Phosphorus", "P"},    Element::Info {"Sulfur", "S"},
+  Element::Info {"Chlorine", "Cl"},     Element::Info {"Argon", "Ar"},
+  Element::Info {"Potassium", "K"},     Element::Info {"Calcium", "Ca"},
+  Element::Info {"Scandium", "Sc"},     Element::Info {"Titanium", "Ti"},
+  Element::Info {"Vanadium", "V"},      Element::Info {"Chromium", "Cr"},
+  Element::Info {"Manganese", "Mn"},    Element::Info {"Iron", "Fe"},
+  Element::Info {"Cobalt", "Co"},       Element::Info {"Nickel", "Ni"},
+  Element::Info {"Copper", "Cu"},       Element::Info {"Zinc", "Zn"},
+  Element::Info {"Gallium", "Ga"},      Element::Info {"Germanium", "Ge"},
+  Element::Info {"Arsenic", "As"},      Element::Info {"Selenium", "Se"},
+  Element::Info {"Bromine", "Br"},      Element::Info {"Krypton", "Kr"},
+  Element::Info {"Rubidium", "Rb"},     Element::Info {"Strontium", "Sr"},
+  Element::Info {"Yttrium", "Y"},       Element::Info {"Zirconium", "Zr"},
+  Element::Info {"Niobium", "Nb"},      Element::Info {"Molbdenum", "Mo"},
+  Element::Info {"Technetium", "Tc"},   Element::Info {"Ruthenium", "Ru"},
+  Element::Info {"Rhodium", "Rh"},      Element::Info {"Palladium", "Pd"},
+  Element::Info {"Silver", "Ag"},       Element::Info {"Cadmium", "Cd"},
+  Element::Info {"Indium", "In"},       Element::Info {"Tin", "Sn"},
+  Element::Info {"Antimony", "Sb"},     Element::Info {"Tellurium", "Te"},
+  Element::Info {"Iodine", "I"},        Element::Info {"Xenon", "Xe"},
+  Element::Info {"Cesium", "Cs"},       Element::Info {"Barium", "Ba"},
+  Element::Info {"Lanthanum", "La"},    Element::Info {"Cerium", "Ce"},
+  Element::Info {"Praseodymium", "Pr"}, Element::Info {"Neodymium", "Nd"},
+  Element::Info {"Promethium", "Pm"},   Element::Info {"Samarium", "Sm"},
+  Element::Info {"Europium", "Eu"},     Element::Info {"Gadolinium", "Gd"},
+  Element::Info {"Terbium", "Tb"},      Element::Info {"Dysprosium", "Dy"},
+  Element::Info {"Holmium", "Ho"},      Element::Info {"Erbium", "Er"},
+  Element::Info {"Thulium", "Tm"},      Element::Info {"Ytterbium", "Yb"},
+  Element::Info {"Lutetium", "Lu"},     Element::Info {"Hafnium", "Hf"},
+  Element::Info {"Tantalum", "Ta"},     Element::Info {"Tungsten", "W"},
+  Element::Info {"Rhenium", "Re"},      Element::Info {"Osmium", "Os"},
+  Element::Info {"Iridium", "Ir"},      Element::Info {"Platinum", "Pt"},
+  Element::Info {"Gold", "Au"},         Element::Info {"Mercury", "Hg"},
+  Element::Info {"Thallium", "Tl"},     Element::Info {"Lead", "Pb"},
+  Element::Info {"Bismuth", "Bi"},      Element::Info {"Polonium", "Po"},
+  Element::Info {"Astatine", "At"},     Element::Info {"Radon", "Rn"},
+  Element::Info {"Francium", "Fr"},     Element::Info {"Radium", "Ra"},
+  Element::Info {"Actinium", "Ac"},     Element::Info {"Thorium", "Th"},
+  Element::Info {"Protactinium", "Pa"}, Element::Info {"Uranium", "U"},
+  Element::Info {"Neptunium", "Np"},    Element::Info {"Plutonium", "Pu"},
+  Element::Info {"Americium", "Am"},    Element::Info {"Curium", "Cm"},
+  Element::Info {"Berkelium", "Bk"},    Element::Info {"Californium", "Cf"},
+  Element::Info {"Einsteinium", "Es"},  Element::Info {"Fermium", "Fm"},
+  Element::Info {"Mendelevium", "Md"},  Element::Info {"Nobelium", "No"},
+  Element::Info {"Lawrencium", "Lr"},   Element::Info {"Rutherfordium", "Rf"},
+  Element::Info {"Dubnium", "Db"},      Element::Info {"Seaborgium", "Sg"},
+  Element::Info {"Bohrium", "Bh"},      Element::Info {"Hassium", "Hs"},
+  Element::Info {"Meitnerium", "Mt"},   Element::Info {"Darmstadtium", "Ds"},
+  Element::Info {"Roentgenium", "Rg"},  Element::Info {"Copernicium", "Cn"},
+  Element::Info {"Nihonium", "Nh"},     Element::Info {"Flerovium", "Fl"},
+  Element::Info {"Moscovium", "Mc"},    Element::Info {"Livermorium", "Lv"},
+  Element::Info {"Tennessine", "Ts"},   Element::Info {"Oganesson", "Og"}
+};
+
+}

--- a/src/python/nuclide.cpp
+++ b/src/python/nuclide.cpp
@@ -1,0 +1,101 @@
+/*
+ * Papillon Nuclear Data Library
+ * Copyright 2021, Hunter Belanger
+ *
+ * hunter.belanger@gmail.com
+ *
+ * This file is part of the Papillon Nuclear Data Library (PapillonNDL).
+ *
+ * PapillonNDL is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PapillonNDL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PapillonNDL. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * */
+#include <pybind11/pybind11.h>
+#include <pybind11/operators.h>
+
+#include <PapillonNDL/zaid.hpp>
+#include <PapillonNDL/element.hpp>
+#include <PapillonNDL/isotope.hpp>
+#include <PapillonNDL/nuclide.hpp>
+
+#include <string>
+
+namespace py = pybind11;
+
+using namespace pndl;
+
+void init_ZAID(py::module& m) {
+  py::class_<ZAID>(m, "ZAID")
+      .def(py::init<uint8_t, uint32_t>())
+      .def("Z", &ZAID::Z)
+      .def("A", &ZAID::A)
+      .def("zaid", &ZAID::zaid)
+      .def(py::self == py::self)
+      .def(py::self < py::self)
+      .def("__repr__", [](const ZAID& z){ return std::to_string(z.zaid()); })
+      .def("__hash__", [](const ZAID& z){ std::hash<ZAID> h; return h(z); });
+}
+
+void init_Element(py::module& m) {
+  py::class_<Element>(m, "Element")
+      .def(py::init<uint8_t>())
+      .def("Z", &Element::Z)
+      .def("atomic_numer", &Element::atomic_number)
+      .def("symbol", &Element::symbol)
+      .def("name", &Element::name)
+      .def("zaid", &Element::zaid)
+      .def(py::self == py::self)
+      .def(py::self < py::self)
+      .def("from_symbol", &Element::from_symbol)
+      .def("from_name", &Element::from_name)
+      .def("__repr__", [](const Element& e){ return e.symbol(); })
+      .def("__hash__", [](const Element& e){ std::hash<Element> h; return h(e); });
+}
+
+void init_Isotope(py::module& m) {
+  py::class_<Isotope>(m, "Isotope")
+      .def(py::init<const Element&, uint32_t>())
+      .def(py::init<uint8_t,uint32_t>())
+      .def("Z", &Isotope::Z)
+      .def("atomic_numer", &Isotope::atomic_number)
+      .def("A", &Isotope::A)
+      .def("atomic_mass", &Isotope::atomic_mass)
+      .def("zaid", &Isotope::zaid)
+      .def("symbol", &Isotope::symbol)
+      .def("element_symbol", &Isotope::element_symbol)
+      .def("element_name", &Isotope::element_name)
+      .def(py::self == py::self)
+      .def(py::self < py::self)
+      .def("__repr__", [](const Isotope& i){ return i.symbol(); })
+      .def("__hash__", [](const Isotope& i){ std::hash<Isotope> h; return h(i); });
+}
+
+void init_Nuclide(py::module& m) {
+  py::class_<Nuclide>(m, "Nuclide")
+      .def(py::init<const Isotope&, uint8_t>())
+      .def(py::init<uint8_t,uint32_t,uint8_t>())
+      .def("Z", &Nuclide::Z)
+      .def("atomic_numer", &Nuclide::atomic_number)
+      .def("A", &Nuclide::A)
+      .def("atomic_mass", &Nuclide::atomic_mass)
+      .def("level", &Nuclide::level)
+      .def("zaid", &Nuclide::zaid)
+      .def("symbol", &Nuclide::symbol)
+      .def("isotope_symbol", &Nuclide::isotope_symbol)
+      .def("element_symbol", &Nuclide::element_symbol)
+      .def("element_name", &Nuclide::element_name)
+      .def(py::self == py::self)
+      .def(py::self < py::self)
+      .def("__repr__", [](const Nuclide& n){ return n.symbol(); })
+      .def("__hash__", [](const Nuclide& n){ std::hash<Nuclide> h; return h(n); });
+}

--- a/src/python/pyPapillonNDL.cpp
+++ b/src/python/pyPapillonNDL.cpp
@@ -78,6 +78,10 @@ extern void init_STNeutron(py::module& m);
 extern void init_CENeutronBase(py::module& m);
 extern void init_STReaction(py::module& m);
 extern void init_PRNG(py::module&);
+extern void init_ZAID(py::module&);
+extern void init_Element(py::module&);
+extern void init_Isotope(py::module&);
+extern void init_Nuclide(py::module&);
 
 PYBIND11_MODULE(pyPapillonNDL, m) {
   init_ACE(m);
@@ -132,6 +136,10 @@ PYBIND11_MODULE(pyPapillonNDL, m) {
   init_CENeutronBase(m);
   init_STNeutron(m);
   init_PRNG(m);
+  init_ZAID(m);
+  init_Element(m);
+  init_Isotope(m);
+  init_Nuclide(m);
 
   m.attr("__author__") = "Hunter Belanger";
   m.attr("__copyright__") = "Copyright 2021, Hunter Belanger";


### PR DESCRIPTION
Creates four new classes: `ZAID`, `Element`, `Isotope`, and `Nuclide`. These will be used to look-up and sort different ACE files from a future data library class, which would contain the information of all possible nuclides, and all possible temperatures. All of these classes implement  `operator==`, `operator<`, and `std::hash<T>`, so that they can be used as keys in containers such as `std::unsorted_map`, or be sorted in some other structure.

It should be possible to represent all known elements and isotopes with this implementation. It is required that 0 < Z <= 118 for `Element`, `Isotope`, and `Nuclide`. It is also required that `Isotope` and `Nuclide` satisfy A < 300. For `Nuclide`, only 5 isomer levels are allowed, which is far more than is ever seen in any nuclear data library, as far as I'm aware.