### PR TITLE
Adds new linearization functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ option(PNDL_TESTS "Build PapillonNDL tests" OFF)
 set(PNDL_SOURCE_LIST src/element.cpp
                      src/tabulated_1d.cpp
                      src/polynomial_1d.cpp
+                     src/linearize.cpp
                      src/ace.cpp
                      src/isotropic.cpp
                      src/equiprobable_angle_bins.cpp
@@ -136,6 +137,7 @@ if(PNDL_PYTHON)
                                     src/python/ace.cpp
                                     src/python/xs_packet.cpp
                                     src/python/function_1d.cpp
+                                    src/python/linearize.cpp
                                     src/python/frame.cpp
                                     src/python/angle_law.cpp
                                     src/python/angle_distribution.cpp

--- a/docs/api/functions.rst
+++ b/docs/api/functions.rst
@@ -24,16 +24,6 @@ Tabulated1D
 
 .. doxygenclass:: pndl::Tabulated1D
 
-Region1D
---------
-
-.. doxygenclass:: pndl::Region1D
-
-MultiRegion1D
--------------
-
-.. doxygenclass:: pndl::MultiRegion1D
-
 Sum1D
 -----
 

--- a/docs/api/tools.rst
+++ b/docs/api/tools.rst
@@ -16,7 +16,7 @@ MCNPLibrary
 .. doxygenclass:: pndl::MCNPLibrary
 
 SerpentLibrary
------------
+--------------
 
 .. doxygenclass:: pndl::SerpentLibrary
 
@@ -54,6 +54,14 @@ Interpolator
 ------------
 
 .. doxygenclass:: pndl::Interpolator
+
+Linearization
+-------------
+
+.. doxygenfunction:: pndl::linearize(const std::vector<double> &x, const std::vector<double> &y, std::function<double(double)> f, double tolerance = 0.001)
+
+.. doxygenfunction:: pndl::linearize(double x_min, double x_max, std::function<double(double)> f, double tolerance = 0.001)
+
 
 ZAID
 ----

--- a/include/PapillonNDL/angle_table.hpp
+++ b/include/PapillonNDL/angle_table.hpp
@@ -29,6 +29,7 @@
  */
 
 #include <PapillonNDL/angle_law.hpp>
+#include <PapillonNDL/legendre.hpp>
 #include <PapillonNDL/pctable.hpp>
 #include <functional>
 
@@ -54,6 +55,12 @@ class AngleTable : public AngleLaw {
    */
   AngleTable(const std::vector<double>& cosines, const std::vector<double>& pdf,
              const std::vector<double>& cdf, Interpolation interp);
+
+  /**
+   * @param legendre Legendre distribution which will be linearized to create an
+   *                 AngleTable.
+   */
+  AngleTable(const Legendre& legendre);
 
   /**
    * @param table PCTable contianing the PDF and CDF for the cosine

--- a/include/PapillonNDL/linearize.hpp
+++ b/include/PapillonNDL/linearize.hpp
@@ -1,0 +1,82 @@
+/*
+ * Papillon Nuclear Data Library
+ * Copyright 2021, Hunter Belanger
+ *
+ * hunter.belanger@gmail.com
+ *
+ * This file is part of the Papillon Nuclear Data Library (PapillonNDL).
+ *
+ * PapillonNDL is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PapillonNDL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PapillonNDL. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * */
+#ifndef PAPILLON_NDL_LINEARIZE_H
+#define PAPILLON_NDL_LINEARIZE_H
+
+/**
+ * @file
+ * @author Hunter Belanger
+ */
+
+#include <PapillonNDL/tabulated_1d.hpp>
+#include <functional>
+#include <vector>
+
+namespace pndl {
+
+/**
+ * @brief Linearizes the function f, keeping the user provided points in
+ *        x and y. The resulting linearized function is returnedd as a
+ *        Tabulated1D.
+ *
+ * @warning The values y[i] MUST agree with the values of f(x[i]). This is not
+ *          checked however, due to the fact that the function f is allowed to
+ *          be discontinuous. A discontinuity is represented with two adjacent
+ *          values in the x array which are equal, each having a difference
+ *          associated y value. If the values y[i] do not equal f(x[i])
+ *          (barring discontinuities), this function may not finish, or may
+ *          yield unexpected results.
+ *
+ * @param x Reference to the vector of x values which will be kept for linear
+ *          interpolation. This vector must be sorted.
+ * @param y Reference to the vector of y values which will be kept for linear
+ *          interpolation. Must be the same length as x.
+ * @param f Function to be linearized.
+ * @param tolerance Maximum relative absolute error for linear interpolation.
+ *                  The default tolerance is 0.001, or 0.1%.
+ */
+Tabulated1D linearize(const std::vector<double>& x,
+                      const std::vector<double>& y,
+                      std::function<double(double)> f,
+                      double tolerance = 0.001);
+
+/**
+ * @brief Linearizes the function f over the interval [x_min, x_max]. The
+ *        resulting function is returned as a Tabulated1D.
+ *
+ * @warning This function may not finish, or may yield unexpected results
+ *          if the function f is discontinuous over the interval.
+ *
+ * @param x_min Minimum x value for linearization.
+ * @param x_max Maximum x value for linearization.
+ * @param f Function to linearize.
+ * @param tolerance Maximum relative absolute error for linear interpolation.
+ *                  The default tolerance is 0.001, or 0.1%.
+ */
+Tabulated1D linearize(double x_min, double x_max,
+                      std::function<double(double)> f,
+                      double tolerance = 0.001);
+
+}  // namespace pndl
+
+#endif

--- a/include/PapillonNDL/tabulated_1d.hpp
+++ b/include/PapillonNDL/tabulated_1d.hpp
@@ -157,6 +157,15 @@ class Tabulated1D : public Function1D {
    */
   double max_x() const { return x_.back(); }
 
+  /**
+   * @brief Linearizes the function to be linearly interpolable to within the
+   *        given tolerance.
+   *
+   * @param tolerance Maximum relative absolute error for linear interpolation.
+   *                  The default tolerance is 0.001, or 0.1%.
+   */
+  void linearize(double tolerance = 0.001);
+
  private:
   class InterpolationRange {
    public:

--- a/src/linearize.cpp
+++ b/src/linearize.cpp
@@ -1,0 +1,101 @@
+/*
+ * Papillon Nuclear Data Library
+ * Copyright 2021, Hunter Belanger
+ *
+ * hunter.belanger@gmail.com
+ *
+ * This file is part of the Papillon Nuclear Data Library (PapillonNDL).
+ *
+ * PapillonNDL is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PapillonNDL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PapillonNDL. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * */
+
+#include <PapillonNDL/interpolation.hpp>
+#include <PapillonNDL/linearize.hpp>
+#include <PapillonNDL/pndl_exception.hpp>
+#include <algorithm>
+#include <cmath>
+#include <vector>
+
+namespace pndl {
+
+Tabulated1D linearize(const std::vector<double>& i_x,
+                      const std::vector<double>& i_y,
+                      std::function<double(double)> f, double tolerance) {
+  std::vector<double> x = i_x;
+  std::vector<double> y = i_y;
+
+  // Do checks on vectors
+  if (x.size() != y.size()) {
+    std::string mssg = "x and y must have the same length.";
+    throw PNDLException(mssg);
+  }
+
+  if (std::is_sorted(x.begin(), x.end()) == false) {
+    std::string mssg = "x must be sorted.";
+    throw PNDLException(mssg);
+  }
+
+  // Bisect intervals until we are linearly interpolable
+  std::size_t i = 0;
+  while (i < (x.size() - 1)) {
+    // Get mid-point x value. If x[i] == x[i+1], this is a discontinuity, so we
+    // continue.
+    if (x[i] == x[i + 1]) {
+      i++;
+      continue;
+    }
+    double x_mid = 0.5 * (x[i] + x[i + 1]);
+
+    // Get interpolated and real function value
+    const double f_interp = 0.5 * (y[i] + y[i + 1]);
+    const double f_real = f(x_mid);
+
+    // Check tolerance
+    const double rel_diff = std::abs((f_interp - f_real) / f_real);
+    if (rel_diff > tolerance) {
+      // Add the mid-point
+      auto xp = x.begin() + i + 1;
+      auto yp = y.begin() + i + 1;
+      x.insert(xp, x_mid);
+      y.insert(yp, f_real);
+    } else {
+      i++;
+    }
+  }
+
+  x.shrink_to_fit();
+  y.shrink_to_fit();
+
+  return Tabulated1D(Interpolation::LinLin, x, y);
+}
+
+Tabulated1D linearize(double x_min, double x_max,
+                      std::function<double(double)> f, double tolerance) {
+  if (x_max <= x_min) {
+    std::string mssg = "x_max must be larger than x_min.";
+    throw PNDLException(mssg);
+  }
+
+  // Initialize vectors for x and y values
+  std::vector<double> x, y;
+  x.push_back(x_min);
+  y.push_back(f(x_min));
+  x.push_back(x_max);
+  y.push_back(f(x_max));
+
+  return linearize(x, y, f, tolerance);
+}
+
+}  // namespace pndl

--- a/src/python/angle_law.cpp
+++ b/src/python/angle_law.cpp
@@ -77,6 +77,7 @@ void init_AngleTable(py::module& m) {
       .def(py::init<const ACE&, size_t>())
       .def(py::init<const std::vector<double>&, const std::vector<double>&,
                     const std::vector<double>&, Interpolation>())
+      .def(py::init<const Legendre&>())
       .def(py::init<const PCTable&>())
       .def("sample_mu", &AngleTable::sample_mu)
       .def("size", &AngleTable::size)

--- a/src/python/function_1d.cpp
+++ b/src/python/function_1d.cpp
@@ -91,7 +91,8 @@ void init_Tabulated1D(py::module& m) {
       .def("x", &Tabulated1D::x)
       .def("y", &Tabulated1D::y)
       .def("min_x", &Tabulated1D::min_x)
-      .def("max_x", &Tabulated1D::max_x);
+      .def("max_x", &Tabulated1D::max_x)
+      .def("linearize", &Tabulated1D::linearize);
 }
 
 void init_Sum1D(py::module& m) {

--- a/src/python/linearize.cpp
+++ b/src/python/linearize.cpp
@@ -1,0 +1,44 @@
+/*
+ * Papillon Nuclear Data Library
+ * Copyright 2021, Hunter Belanger
+ *
+ * hunter.belanger@gmail.com
+ *
+ * This file is part of the Papillon Nuclear Data Library (PapillonNDL).
+ *
+ * PapillonNDL is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PapillonNDL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PapillonNDL. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * */
+#include <pybind11/functional.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include <PapillonNDL/function_1d.hpp>
+#include <PapillonNDL/linearize.hpp>
+
+namespace py = pybind11;
+
+using namespace pndl;
+
+void init_Linearize(py::module& m) {
+  m.def(
+      "linearize",
+      py::overload_cast<const std::vector<double>&, const std::vector<double>&,
+                        std::function<double(double)>, double>(&linearize));
+
+  m.def(
+      "linearize",
+      py::overload_cast<double, double, std::function<double(double)>, double>(
+          &linearize));
+}

--- a/src/python/pyPapillonNDL.cpp
+++ b/src/python/pyPapillonNDL.cpp
@@ -37,6 +37,7 @@ extern void init_Polynomial1D(py::module&);
 extern void init_Tabulated1D(py::module&);
 extern void init_Sum1D(py::module&);
 extern void init_Difference1D(py::module&);
+extern void init_Linearize(py::module&);
 extern void init_AngleLaw(py::module&);
 extern void init_Isotropic(py::module&);
 extern void init_EquiprobableAngleBins(py::module&);
@@ -99,6 +100,7 @@ PYBIND11_MODULE(pyPapillonNDL, m) {
   init_Tabulated1D(m);
   init_Sum1D(m);
   init_Difference1D(m);
+  init_Linearize(m);
   init_AngleLaw(m);
   init_Isotropic(m);
   init_EquiprobableAngleBins(m);

--- a/src/tabulated_1d.cpp
+++ b/src/tabulated_1d.cpp
@@ -22,6 +22,9 @@
  * */
 #include <PapillonNDL/pndl_exception.hpp>
 #include <PapillonNDL/tabulated_1d.hpp>
+#include <PapillonNDL/linearize.hpp>
+#include <cstdint>
+#include "PapillonNDL/interpolation.hpp"
 
 namespace pndl {
 
@@ -107,6 +110,26 @@ Tabulated1D::Tabulated1D(Interpolation interp, const std::vector<double>& x,
         "Tabulated1D.";
     error.add_to_exception(mssg);
     throw error;
+  }
+}
+
+void Tabulated1D::linearize(double tolerance) {
+  // Check if we are already linear
+  if (interpolation_.size() == 1 &&
+      interpolation_[0] == Interpolation::LinLin) {
+    return;
+  }
+
+  std::vector<double> x = x_;
+  std::vector<double> y = y_;
+
+  try {
+    Tabulated1D new_tab = pndl::linearize(x, y, *this, tolerance);
+    *this = new_tab;
+  } catch (PNDLException& err) {
+    std::string mssg = "Could not linearize Tabulated1D.";
+    err.add_to_exception(mssg);
+    throw err;
   }
 }
 

--- a/src/tabulated_1d.cpp
+++ b/src/tabulated_1d.cpp
@@ -20,10 +20,11 @@
  * along with PapillonNDL. If not, see <https://www.gnu.org/licenses/>.
  *
  * */
+#include <PapillonNDL/linearize.hpp>
 #include <PapillonNDL/pndl_exception.hpp>
 #include <PapillonNDL/tabulated_1d.hpp>
-#include <PapillonNDL/linearize.hpp>
 #include <cstdint>
+
 #include "PapillonNDL/interpolation.hpp"
 
 namespace pndl {


### PR DESCRIPTION
This PR adds two new functions to linearize one-dimensional functions. A linearize method has also been added to `Tabulated1D`. It is now also possible to create an `AngleTable` from a `Legendre` instance; a tabulated distribution is usually much more efficient than using rejection sampling as is done in the `Legendre` class. 