### PR TITLE
Implement Sampling of Velocity of Target for elastic scattering

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ set(PNDL_SOURCE_LIST src/element.cpp
                      src/tabular_energy_angle.cpp
                      src/multiple_distribution.cpp
                      src/cm_distribution.cpp
+                     src/svt.cpp
                      src/elastic_svt.cpp
                      src/energy_grid.cpp
                      src/cross_section.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ set(PNDL_SOURCE_LIST src/element.cpp
                      src/tabular_energy_angle.cpp
                      src/multiple_distribution.cpp
                      src/cm_distribution.cpp
+                     src/elastic_svt.cpp
                      src/energy_grid.cpp
                      src/cross_section.cpp
                      src/delayed_group.cpp

--- a/docs/api/angle_energy.rst
+++ b/docs/api/angle_energy.rst
@@ -68,3 +68,8 @@ Absorption
 ----------
 
 .. doxygenclass:: pndl::Absorption
+
+ElasticSVT
+----------
+
+.. doxygenclass:: pndl::ElasticSVT

--- a/include/PapillonNDL/elastic_svt.hpp
+++ b/include/PapillonNDL/elastic_svt.hpp
@@ -35,20 +35,53 @@
 
 namespace pndl {
 
+/**
+ * @brief This class is used to sample elastic scattering of neutrons off of a
+ *        nuclide. It uses the Sampling of Velocity of Target (SVT) algorithm.
+ *        This approach is also sometimes refered to as the Constant Cross
+ *        Section (CXS) approximation. It assumes that the microscopic
+ *        scattering cross section is approximately constant over the range of
+ *        reletive energies which could be observed by the incident neutron (due
+ *        to the direction of the target nuclides velcity being random and
+ *        isotropically distributed). This method is standard in many Monte
+ *        Carlo codes. Despite its ubiquity, it is known to yield inaccurate
+ *        results for heavy nuclides which have scattering resonances at low
+ *        energies. For these heavy nuclide, the Doppler Broadened Rejection
+ *        Correction (DBRC) algorithm is better, as it is an exact treatment.
+ *
+ *        At certain energies, it becomes reasonable to make the approximation
+ *        that the target nuclide is at rest, and has no thermal motion. The
+ *        threshold for applying this approximation is set with the
+ *        tar_threshold parameter. If the incident energy of the neutron (Ein)
+ *        is larger than tar_threshold * temperature * k (where k is the
+ *        Boltzmann constant), then the target is taken to be stationary. One
+ *        exception to this rule is for nuclides with an AWR < 1 (only H1).
+ *        Since H1 is actually has a slightly smaller mass than a neutron, the
+ *        target at rest approximation is generally inadequate.
+ */
 class ElasticSVT : public AngleEnergy {
  public:
+  /**
+   * @param angle The AngleDistribution for elastic scattering. This
+   *              distribution must be given in the center of mass frame.
+   * @param awr Atomic weight ratio of the nuclide.
+   * @param tempereature Temperature in Kelvin of the nuclide.
+   * @param tar_threshold The threshold for applying the target-at-rest
+   *                      approximation.
+   */
   ElasticSVT(const AngleDistribution& angle, double awr, double temperature,
              double tar_threshold);
 
   AngleEnergyPacket sample_angle_energy(
       double E_in, std::function<double()> rng) const override final;
 
-  std::optional<double> angle_pdf(double E_in, double mu) const override final {
+  std::optional<double> angle_pdf(double /*E_in*/,
+                                  double /*mu*/) const override final {
     return std::nullopt;
   }
 
-  std::optional<double> pdf(double E_in, double mu,
-                            double E_out) const override final {
+  std::optional<double> pdf(double /*E_in*/, double /*mu*/,
+                            double /*E_out*/) const override final {
     return std::nullopt;
   }
 
@@ -64,9 +97,9 @@ class ElasticSVT : public AngleEnergy {
   double awr() const { return awr_; }
 
   /**
-   * @breif Returns the temperature for the nuclide.
+   * @breif Returns the temperature for the nuclide in Kelvin.
    */
-  double temperature() const { return awr_; }
+  double temperature() const;
 
   /**
    * @brief Returns the threshold for the application of the Target At Rest
@@ -78,7 +111,7 @@ class ElasticSVT : public AngleEnergy {
   struct Vector {
     double x, y, z;
 
-    Vector(double x, double y, double z): x(x), y(y), z(z) {}
+    Vector(double x, double y, double z) : x(x), y(y), z(z) {}
 
     Vector operator+(const Vector& v) const {
       return {x + v.x, y + v.y, z + v.z};
@@ -101,7 +134,7 @@ class ElasticSVT : public AngleEnergy {
 
   AngleDistribution angle_;
   double awr_;
-  double temperature_;
+  double kT_;  // Temperature in MeV
   double tar_threshold_;
 
   Vector sample_target_velocity(double Ein, std::function<double()> rng) const;

--- a/include/PapillonNDL/elastic_svt.hpp
+++ b/include/PapillonNDL/elastic_svt.hpp
@@ -108,36 +108,10 @@ class ElasticSVT : public AngleEnergy {
   double tar_threshold() const { return tar_threshold_; }
 
  private:
-  struct Vector {
-    double x, y, z;
-
-    Vector(double x, double y, double z) : x(x), y(y), z(z) {}
-
-    Vector operator+(const Vector& v) const {
-      return {x + v.x, y + v.y, z + v.z};
-    }
-
-    Vector operator-(const Vector& v) const {
-      return {x - v.x, y - v.y, z - v.z};
-    }
-
-    Vector operator*(const double& c) const { return {x * c, y * c, z * c}; }
-
-    Vector operator/(const double& c) const { return {x / c, y / c, z / c}; }
-
-    double dot(const Vector& v) const { return x * v.x + y * v.y + z * v.z; }
-
-    double magnitude() const;
-
-    Vector rotate(double mu, double phi) const;
-  };
-
   AngleDistribution angle_;
   double awr_;
   double kT_;  // Temperature in MeV
   double tar_threshold_;
-
-  Vector sample_target_velocity(double Ein, std::function<double()> rng) const;
 };
 
 }  // namespace pndl

--- a/include/PapillonNDL/elastic_svt.hpp
+++ b/include/PapillonNDL/elastic_svt.hpp
@@ -65,12 +65,14 @@ class ElasticSVT : public AngleEnergy {
    * @param angle The AngleDistribution for elastic scattering. This
    *              distribution must be given in the center of mass frame.
    * @param awr Atomic weight ratio of the nuclide.
-   * @param tempereature Temperature in Kelvin of the nuclide.
-   * @param tar_threshold The threshold for applying the target-at-rest
-   *                      approximation.
+   * @param temperature Temperature in Kelvin of the nuclide.
+   * @param use_tar Flag for using the Target At Rest approximation. Default
+   *                value is true.
+   * @param tar_threshold The threshold for applying the Target At Rest
+   *                      approximation. Default value is 400.
    */
   ElasticSVT(const AngleDistribution& angle, double awr, double temperature,
-             double tar_threshold);
+             bool use_tar = true, double tar_threshold = 400.);
 
   AngleEnergyPacket sample_angle_energy(
       double E_in, std::function<double()> rng) const override final;
@@ -102,6 +104,13 @@ class ElasticSVT : public AngleEnergy {
   double temperature() const;
 
   /**
+   * @brief If true, the Target At Rest approximation is used for incident
+   *        energies which are larger than tar_threshold * kT. If false, the
+   *        Target At Rest approximation is never used.
+   */
+  bool use_tar() const { return use_tar_; };
+
+  /**
    * @brief Returns the threshold for the application of the Target At Rest
    *        approximation.
    */
@@ -111,6 +120,7 @@ class ElasticSVT : public AngleEnergy {
   AngleDistribution angle_;
   double awr_;
   double kT_;  // Temperature in MeV
+  bool use_tar_;
   double tar_threshold_;
 };
 

--- a/include/PapillonNDL/elastic_svt.hpp
+++ b/include/PapillonNDL/elastic_svt.hpp
@@ -1,0 +1,112 @@
+/*
+ * Papillon Nuclear Data Library
+ * Copyright 2021, Hunter Belanger
+ *
+ * hunter.belanger@gmail.com
+ *
+ * This file is part of the Papillon Nuclear Data Library (PapillonNDL).
+ *
+ * PapillonNDL is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PapillonNDL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PapillonNDL. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * */
+#ifndef PAPILLON_NDL_ELASTIC_SVT_H
+#define PAPILLON_NDL_ELASTIC_SVT_H
+
+#include <PapillonNDL/angle_distribution.hpp>
+#include <PapillonNDL/angle_energy.hpp>
+#include <functional>
+#include <optional>
+
+/**
+ * @file
+ * @author Hunter Belanger
+ */
+
+namespace pndl {
+
+class ElasticSVT : public AngleEnergy {
+ public:
+  ElasticSVT(const AngleDistribution& angle, double awr, double temperature,
+             double tar_threshold);
+
+  AngleEnergyPacket sample_angle_energy(
+      double E_in, std::function<double()> rng) const override final;
+
+  std::optional<double> angle_pdf(double E_in, double mu) const override final {
+    return std::nullopt;
+  }
+
+  std::optional<double> pdf(double E_in, double mu,
+                            double E_out) const override final {
+    return std::nullopt;
+  }
+
+  /**
+   * @brief Returns the AngleDistribution which describes the distribution for
+   *        the cosine of the scattering angle in the center-of-mass frame.
+   */
+  const AngleDistribution& angle_distribution() const { return angle_; }
+
+  /**
+   * @breif Returns the Atomic Weight Ratio for the nuclide.
+   */
+  double awr() const { return awr_; }
+
+  /**
+   * @breif Returns the temperature for the nuclide.
+   */
+  double temperature() const { return awr_; }
+
+  /**
+   * @brief Returns the threshold for the application of the Target At Rest
+   *        approximation.
+   */
+  double tar_threshold() const { return tar_threshold_; }
+
+ private:
+  struct Vector {
+    double x, y, z;
+
+    Vector(double x, double y, double z): x(x), y(y), z(z) {}
+
+    Vector operator+(const Vector& v) const {
+      return {x + v.x, y + v.y, z + v.z};
+    }
+
+    Vector operator-(const Vector& v) const {
+      return {x - v.x, y - v.y, z - v.z};
+    }
+
+    Vector operator*(const double& c) const { return {x * c, y * c, z * c}; }
+
+    Vector operator/(const double& c) const { return {x / c, y / c, z / c}; }
+
+    double dot(const Vector& v) const { return x * v.x + y * v.y + z * v.z; }
+
+    double magnitude() const;
+
+    Vector rotate(double mu, double phi) const;
+  };
+
+  AngleDistribution angle_;
+  double awr_;
+  double temperature_;
+  double tar_threshold_;
+
+  Vector sample_target_velocity(double Ein, std::function<double()> rng) const;
+};
+
+}  // namespace pndl
+
+#endif

--- a/src/constants.hpp
+++ b/src/constants.hpp
@@ -23,6 +23,9 @@
 #ifndef PAPILLON_NDL_CONSTANTS_H
 #define PAPILLON_NDL_CONSTANTS_H
 
+#include <limits>
+#include <locale>
+
 constexpr double SEC_TO_SHAKE = 1.E-8;
 constexpr double SHAKE_TO_SEC = 1.E8;
 constexpr double EV_TO_K = 1.160451812E4;
@@ -30,6 +33,7 @@ constexpr double K_TO_EV = 1. / EV_TO_K;
 constexpr double MEV_TO_EV = 1.E6;
 constexpr double EV_TO_MEV = 1.E-6;
 constexpr double PI = 3.14159265358979323846264338327950288;
+constexpr double INF = std::numeric_limits<double>::max();
 constexpr unsigned int N_LETHARGY_BINS = 8192;
 
 #endif  // PAPILLON_NDL_CONSTANTS_H

--- a/src/constants.hpp
+++ b/src/constants.hpp
@@ -26,6 +26,7 @@
 constexpr double SEC_TO_SHAKE = 1.E-8;
 constexpr double SHAKE_TO_SEC = 1.E8;
 constexpr double EV_TO_K = 1.160451812E4;
+constexpr double K_TO_EV = 1. / EV_TO_K;
 constexpr double MEV_TO_EV = 1.E6;
 constexpr double EV_TO_MEV = 1.E-6;
 constexpr double PI = 3.14159265358979323846264338327950288;

--- a/src/elastic_svt.cpp
+++ b/src/elastic_svt.cpp
@@ -1,0 +1,168 @@
+/*
+ * Papillon Nuclear Data Library
+ * Copyright 2021, Hunter Belanger
+ *
+ * hunter.belanger@gmail.com
+ *
+ * This file is part of the Papillon Nuclear Data Library (PapillonNDL).
+ *
+ * PapillonNDL is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PapillonNDL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PapillonNDL. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * */
+
+#include <PapillonNDL/elastic_svt.hpp>
+#include <PapillonNDL/pndl_exception.hpp>
+#include <cmath>
+#include <functional>
+
+#include "constants.hpp"
+
+namespace pndl {
+
+ElasticSVT::ElasticSVT(const AngleDistribution& angle, double awr,
+                       double temperature, double tar_threshold)
+    : angle_(angle),
+      awr_(awr),
+      temperature_(temperature),
+      tar_threshold_(tar_threshold) {
+  if (awr_ <= 0.) {
+    std::string mssg = "Atomic weight ratio must be greater than zero.";
+    throw PNDLException(mssg);
+  }
+
+  if (temperature_ < 0.) {
+    std::string mssg = "Temperature must be greater than or equal to zero.";
+    throw PNDLException(mssg);
+  }
+
+  if (tar_threshold_ < 0.) {
+    std::string mssg =
+        "Target At Rest threshold must be greater than or equal to zero.";
+    throw PNDLException(mssg);
+  }
+}
+
+inline double ElasticSVT::Vector::magnitude() const {
+  return std::sqrt(x * x + y * y + z * z);
+}
+
+inline ElasticSVT::Vector ElasticSVT::Vector::rotate(double mu, double phi) const {
+  double xo, yo, zo;
+  const double c = std::cos(phi);
+  const double s = std::sin(phi);
+  const double C = std::sqrt(1. - mu*mu);
+
+  if (std::abs(1. - z*z) > 1.E-10) {
+    const double denom = std::sqrt(1. - z*z);
+
+    xo = x*mu + C*(c*x*z - s*y)/denom;
+    yo = y*mu + C*(c*y*z + s*x)/denom;
+    zo = z*mu - c*C*denom;
+  } else {
+    const double denom = std::sqrt(1. - y*y);
+
+    xo = x*mu + C*(c*x*y + s*z)/denom;
+    yo = y*mu - c*C*denom;
+    zo = z*mu + C*(c*y*z - s*x)/denom;
+  }
+
+  return {xo, yo, zo};
+}
+
+AngleEnergyPacket ElasticSVT::sample_angle_energy(
+    double E_in, std::function<double()> rng) const {
+  // Get the "velocity" of the incident neutron in the lab frame
+  const Vector v_n = Vector(0., 0., 1.) * std::sqrt(E_in);
+
+  // Get the "velocity" of the target nuclide
+  const Vector v_t = sample_target_velocity(rng);
+
+  // Calculate the "velocity" of the center of mass.
+  const Vector v_cm = (v_n + (v_t * awr_)) / (awr_ + 1.);
+
+  // Calculate the "velocity" of the neutron in the CM frame
+  const Vector V_n = v_n - v_cm;
+
+  // Calculate the "speed" in the CM frame
+  const double S_n = V_n.magnitude();
+
+  // Calculate direction in the CM frame
+  const Vector U_n = V_n / S_n;
+
+  // Sample the scattering angle in the CM frame
+  const double mu_cm = angle_.sample_angle(E_in, rng);
+
+  // Get the outgoing velocity in the CM frame
+  const Vector V_n_out = U_n.rotate(mu_cm, 2. * PI * rng()) * S_n;
+
+  // Get the outgoing velocity in the LAB frame
+  const Vector v_n_out = V_n_out + v_cm;
+
+  // Calculate "speed" in the LAB frame
+  const double S_out = v_n_out.magnitude();
+
+  // Calculate outgoing energy in LAB frame
+  const double E_out = S_out * S_out;
+
+  // Calculate the cosine of the scattering angle in the LAB frame
+  const double mu_lab = v_n.dot(v_n_out);
+
+  return {mu_lab, E_out};
+}
+
+ElasticSVT::Vector ElasticSVT::sample_target_velocity(
+    double Ein, std::function<double()> rng) const {
+  if (Ein >= tar_threshold_ * temperature_ * K_TO_EV * EV_TO_MEV && awr_ > 1.) {
+    return {0., 0., 0.};
+  }
+
+  const double y =
+      std::sqrt(0.5 * awr_ * Ein / (temperature_ * K_TO_EV * EV_TO_MEV));
+  double x_sqrd = 0.;
+  double mu = 0.;
+
+  const double P_C49 = 2. / (std::sqrt(PI) * y + 2.);
+
+  bool sample_velocity = true;
+  while (sample_velocity) {
+    if (rng() < P_C49) {
+      // Sample x from the distribution C49 in MC sampler
+      x_sqrd = -std::log(rng() * rng());
+    } else {
+      // Sample x from the distribution C61 in MC sampler
+      const double c = std::cos(PI / 2.0 * rng());
+      x_sqrd = -std::log(rng()) - std::log(rng()) * c * c;
+    }
+
+    const double x = std::sqrt(x_sqrd);
+    mu = 2. * rng() - 1.;
+    const double P_accept =
+        std::sqrt(y * y + x_sqrd - 2. * y * x * mu) / (x + y);
+
+    if (rng() < P_accept) sample_velocity = false;
+  }
+
+  // Get speed of target
+  double s_t =
+      std::sqrt(x_sqrd * 2. * temperature_ * K_TO_EV * EV_TO_MEV / awr_);
+
+  // Use mu to get the direction vector of the target. We know in the sample
+  // method that we always assume the same incident neutron vector:
+  const Vector u_n{0., 0., 1.};
+  Vector u_t = u_n.rotate(mu, 2.*PI*rng());
+
+  return u_t * s_t;
+}
+
+}  // namespace pndl

--- a/src/elastic_svt.cpp
+++ b/src/elastic_svt.cpp
@@ -27,6 +27,8 @@
 #include <functional>
 
 #include "constants.hpp"
+#include "svt.hpp"
+#include "vector.hpp"
 
 namespace pndl {
 
@@ -55,34 +57,6 @@ ElasticSVT::ElasticSVT(const AngleDistribution& angle, double awr,
 
 double ElasticSVT::temperature() const { return kT_ * MEV_TO_EV * EV_TO_K; }
 
-inline double ElasticSVT::Vector::magnitude() const {
-  return std::sqrt(x * x + y * y + z * z);
-}
-
-inline ElasticSVT::Vector ElasticSVT::Vector::rotate(double mu,
-                                                     double phi) const {
-  double xo, yo, zo;
-  const double c = std::cos(phi);
-  const double s = std::sin(phi);
-  const double C = std::sqrt(1. - mu * mu);
-
-  if (std::abs(1. - z * z) > 1.E-10) {
-    const double denom = std::sqrt(1. - z * z);
-
-    xo = x * mu + C * (c * x * z - s * y) / denom;
-    yo = y * mu + C * (c * y * z + s * x) / denom;
-    zo = z * mu - c * C * denom;
-  } else {
-    const double denom = std::sqrt(1. - y * y);
-
-    xo = x * mu + C * (c * x * y + s * z) / denom;
-    yo = y * mu - c * C * denom;
-    zo = z * mu + C * (c * y * z - s * x) / denom;
-  }
-
-  return {xo, yo, zo};
-}
-
 AngleEnergyPacket ElasticSVT::sample_angle_energy(
     double E_in, std::function<double()> rng) const {
   // Direction in
@@ -92,7 +66,10 @@ AngleEnergyPacket ElasticSVT::sample_angle_energy(
   const Vector v_n = u_n * std::sqrt(E_in);
 
   // Get the "velocity" of the target nuclide
-  const Vector v_t = sample_target_velocity(E_in, rng);
+  bool TAR = false;
+  if (E_in >= tar_threshold_ * kT_ && awr_ > 1.) TAR = true;
+  const Vector v_t =
+      TAR ? Vector(0., 0., 0.) : sample_target_velocity(E_in, kT_, awr_, rng);
 
   // Calculate the "velocity" of the center of mass.
   const Vector v_cm = (v_n + (v_t * awr_)) / (awr_ + 1.);
@@ -128,48 +105,6 @@ AngleEnergyPacket ElasticSVT::sample_angle_energy(
   const double mu_lab = u_n.dot(u_n_out);
 
   return {mu_lab, E_out};
-}
-
-ElasticSVT::Vector ElasticSVT::sample_target_velocity(
-    double Ein, std::function<double()> rng) const {
-  if (Ein >= tar_threshold_ * kT_ && awr_ > 1.) {
-    return {0., 0., 0.};
-  }
-
-  const double y = std::sqrt(awr_ * Ein / kT_);
-  double x_sqrd = 0.;
-  double mu = 0.;
-
-  const double P_C49 = 2. / (std::sqrt(PI) * y + 2.);
-
-  bool sample_velocity = true;
-  while (sample_velocity) {
-    if (rng() < P_C49) {
-      // Sample x from the distribution C49 in MC sampler
-      x_sqrd = -std::log(rng() * rng());
-    } else {
-      // Sample x from the distribution C61 in MC sampler
-      const double c = std::cos(PI / 2.0 * rng());
-      x_sqrd = -std::log(rng()) - std::log(rng()) * c * c;
-    }
-
-    const double x = std::sqrt(x_sqrd);
-    mu = 2. * rng() - 1.;
-    const double P_accept =
-        std::sqrt(y * y + x_sqrd - 2. * y * x * mu) / (x + y);
-
-    if (rng() < P_accept) sample_velocity = false;
-  }
-
-  // Get speed of target
-  double s_t = std::sqrt(x_sqrd * kT_ / awr_);
-
-  // Use mu to get the direction vector of the target. We know in the sample
-  // method that we always assume the same incident neutron vector:
-  const Vector u_n{0., 0., 1.};
-  const Vector u_t = u_n.rotate(mu, 2. * PI * rng());
-
-  return u_t * s_t;
 }
 
 }  // namespace pndl

--- a/src/elastic_svt.cpp
+++ b/src/elastic_svt.cpp
@@ -33,10 +33,11 @@
 namespace pndl {
 
 ElasticSVT::ElasticSVT(const AngleDistribution& angle, double awr,
-                       double temperature, double tar_threshold)
+                       double temperature, bool use_tar, double tar_threshold)
     : angle_(angle),
       awr_(awr),
       kT_(temperature * K_TO_EV * EV_TO_MEV),
+      use_tar_(use_tar),
       tar_threshold_(tar_threshold) {
   if (awr_ <= 0.) {
     std::string mssg = "Atomic weight ratio must be greater than zero.";
@@ -53,6 +54,8 @@ ElasticSVT::ElasticSVT(const AngleDistribution& angle, double awr,
         "Target At Rest threshold must be greater than or equal to zero.";
     throw PNDLException(mssg);
   }
+
+  if (use_tar_ == false) tar_threshold_ = INF;
 }
 
 double ElasticSVT::temperature() const { return kT_ * MEV_TO_EV * EV_TO_K; }
@@ -66,8 +69,7 @@ AngleEnergyPacket ElasticSVT::sample_angle_energy(
   const Vector v_n = u_n * std::sqrt(E_in);
 
   // Get the "velocity" of the target nuclide
-  bool TAR = false;
-  if (E_in >= tar_threshold_ * kT_ && awr_ > 1.) TAR = true;
+  const bool TAR = (use_tar_ && E_in >= tar_threshold_ * kT_) ? true : false;
   const Vector v_t =
       TAR ? Vector(0., 0., 0.) : sample_target_velocity(E_in, kT_, awr_, rng);
 

--- a/src/python/angle_energy.cpp
+++ b/src/python/angle_energy.cpp
@@ -296,11 +296,14 @@ void init_Absorption(py::module& m) {
 void init_ElasticSVT(py::module& m) {
   py::class_<ElasticSVT, AngleEnergy, std::shared_ptr<ElasticSVT>>(m,
                                                                    "ElasticSVT")
-      .def(py::init<const AngleDistribution&, double, double, double>())
+      .def(py::init<const AngleDistribution&, double, double, bool, double>(),
+           py::arg("angle"), py::arg("awr"), py::arg("temperature"),
+           py::arg("use_tar") = true, py::arg("tar_threshold") = 400.)
       .def("sample_angle_energy", &ElasticSVT::sample_angle_energy)
       .def("angle_pdf", &ElasticSVT::angle_pdf)
       .def("pdf", &ElasticSVT::pdf)
       .def("awr", &ElasticSVT::awr)
+      .def("use_tar", &ElasticSVT::use_tar)
       .def("tar_threshold", &ElasticSVT::tar_threshold)
       .def("temperature", &ElasticSVT::temperature);
 }

--- a/src/python/angle_energy.cpp
+++ b/src/python/angle_energy.cpp
@@ -20,6 +20,8 @@
  * along with PapillonNDL. If not, see <https://www.gnu.org/licenses/>.
  *
  * */
+#include "PapillonNDL/angle_energy.hpp"
+
 #include <pybind11/functional.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
@@ -28,6 +30,7 @@
 #include <PapillonNDL/cm_distribution.hpp>
 #include <PapillonNDL/continuous_energy_discrete_cosines.hpp>
 #include <PapillonNDL/discrete_cosines_energies.hpp>
+#include <PapillonNDL/elastic_svt.hpp>
 #include <PapillonNDL/energy_angle_table.hpp>
 #include <PapillonNDL/kalbach.hpp>
 #include <PapillonNDL/kalbach_table.hpp>
@@ -288,4 +291,16 @@ void init_Absorption(py::module& m) {
       .def("sample_angle_energy", &Absorption::sample_angle_energy)
       .def("angle_pdf", &Absorption::angle_pdf)
       .def("pdf", &Absorption::pdf);
+}
+
+void init_ElasticSVT(py::module& m) {
+  py::class_<ElasticSVT, AngleEnergy, std::shared_ptr<ElasticSVT>>(m,
+                                                                   "ElasticSVT")
+      .def(py::init<const AngleDistribution&, double, double, double>())
+      .def("sample_angle_energy", &ElasticSVT::sample_angle_energy)
+      .def("angle_pdf", &ElasticSVT::angle_pdf)
+      .def("pdf", &ElasticSVT::pdf)
+      .def("awr", &ElasticSVT::awr)
+      .def("tar_threshold", &ElasticSVT::tar_threshold)
+      .def("temperature", &ElasticSVT::temperature);
 }

--- a/src/python/pyPapillonNDL.cpp
+++ b/src/python/pyPapillonNDL.cpp
@@ -56,6 +56,7 @@ extern void init_Watt(py::module&);
 extern void init_AngleEnergyPacket(py::module&);
 extern void init_AngleEnergy(py::module&);
 extern void init_Uncorrelated(py::module&);
+extern void init_ElasticSVT(py::module&);
 extern void init_NBody(py::module&);
 extern void init_KalbachTable(py::module&);
 extern void init_Kalbach(py::module&);
@@ -119,6 +120,7 @@ PYBIND11_MODULE(pyPapillonNDL, m) {
   init_AngleEnergyPacket(m);
   init_AngleEnergy(m);
   init_Uncorrelated(m);
+  init_ElasticSVT(m);
   init_NBody(m);
   init_KalbachTable(m);
   init_Kalbach(m);

--- a/src/svt.cpp
+++ b/src/svt.cpp
@@ -1,0 +1,67 @@
+/*
+ * Papillon Nuclear Data Library
+ * Copyright 2021, Hunter Belanger
+ *
+ * hunter.belanger@gmail.com
+ *
+ * This file is part of the Papillon Nuclear Data Library (PapillonNDL).
+ *
+ * PapillonNDL is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PapillonNDL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PapillonNDL. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * */
+
+#include "svt.hpp"
+
+namespace pndl {
+
+Vector sample_target_velocity(const double& Ein, const double& kT,
+                              const double& awr,
+                              const std::function<double()>& rng) {
+  const double y = std::sqrt(awr * Ein / kT);
+  double x_sqrd = 0.;
+  double mu = 0.;
+
+  const double P_C49 = 2. / (std::sqrt(PI) * y + 2.);
+
+  bool sample_velocity = true;
+  while (sample_velocity) {
+    if (rng() < P_C49) {
+      // Sample x from the distribution C49 in MC sampler
+      x_sqrd = -std::log(rng() * rng());
+    } else {
+      // Sample x from the distribution C61 in MC sampler
+      const double c = std::cos(PI / 2.0 * rng());
+      x_sqrd = -std::log(rng()) - std::log(rng()) * c * c;
+    }
+
+    const double x = std::sqrt(x_sqrd);
+    mu = 2. * rng() - 1.;
+    const double P_accept =
+        std::sqrt(y * y + x_sqrd - 2. * y * x * mu) / (x + y);
+
+    if (rng() < P_accept) sample_velocity = false;
+  }
+
+  // Get speed of target
+  double s_t = std::sqrt(x_sqrd * kT / awr);
+
+  // Use mu to get the direction vector of the target. We know in the sample
+  // method that we always assume the same incident neutron vector:
+  const Vector u_n{0., 0., 1.};
+  const Vector u_t = u_n.rotate(mu, 2. * PI * rng());
+
+  return u_t * s_t;
+}
+
+}  // namespace pndl

--- a/src/svt.hpp
+++ b/src/svt.hpp
@@ -1,0 +1,47 @@
+/*
+ * Papillon Nuclear Data Library
+ * Copyright 2021, Hunter Belanger
+ *
+ * hunter.belanger@gmail.com
+ *
+ * This file is part of the Papillon Nuclear Data Library (PapillonNDL).
+ *
+ * PapillonNDL is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PapillonNDL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PapillonNDL. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * */
+#ifndef PAPILLON_NDL_SVT_H
+#define PAPILLON_NDL_SVT_H
+
+#include <functional>
+
+#include "vector.hpp"
+
+namespace pndl {
+
+/**
+ * @brief Samples the velocity of a target nuclide from a Maxwelliam spectrum.
+ *        It is always assumed that the direction of the incident neutron is
+ *        (0,0,1).
+ * @param Ein Incident energy of the neutron in MeV.
+ * @param kT Temperature of the "free-gas" in MeV.
+ * @param awr Atomic weight ratio of the nuclide.
+ * @param rng Random number generator function.
+ */
+Vector sample_target_velocity(const double& Ein, const double& kT,
+                              const double& awr,
+                              const std::function<double()>& rng);
+
+}  // namespace pndl
+
+#endif

--- a/src/svt.hpp
+++ b/src/svt.hpp
@@ -30,9 +30,10 @@
 namespace pndl {
 
 /**
- * @brief Samples the velocity of a target nuclide from a Maxwelliam spectrum.
- *        It is always assumed that the direction of the incident neutron is
- *        (0,0,1).
+ * @brief Samples the velocity of a target nuclide from a Maxwelliam spectrum,
+ *        while assuming that the elastic scatting cross section is constant in
+ *        the vicinity of Ein. It is always assumed that the direction of the
+ *        incident neutron is (0,0,1).
  * @param Ein Incident energy of the neutron in MeV.
  * @param kT Temperature of the "free-gas" in MeV.
  * @param awr Atomic weight ratio of the nuclide.

--- a/src/vector.hpp
+++ b/src/vector.hpp
@@ -1,0 +1,87 @@
+/*
+ * Papillon Nuclear Data Library
+ * Copyright 2021, Hunter Belanger
+ *
+ * hunter.belanger@gmail.com
+ *
+ * This file is part of the Papillon Nuclear Data Library (PapillonNDL).
+ *
+ * PapillonNDL is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PapillonNDL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PapillonNDL. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * */
+#ifndef PAPILLON_NDL_VECTOR_H
+#define PAPILLON_NDL_VECTOR_H
+
+#include <cmath>
+
+#include "constants.hpp"
+
+namespace pndl {
+struct Vector {
+  double x, y, z;
+
+  Vector(double x, double y, double z) : x(x), y(y), z(z) {}
+
+  Vector operator+(const Vector& v) const {
+    return {x + v.x, y + v.y, z + v.z};
+  }
+
+  Vector operator-(const Vector& v) const {
+    return {x - v.x, y - v.y, z - v.z};
+  }
+
+  Vector operator*(const double& c) const { return {x * c, y * c, z * c}; }
+
+  Vector operator/(const double& c) const { return {x / c, y / c, z / c}; }
+
+  double dot(const Vector& v) const { return x * v.x + y * v.y + z * v.z; }
+
+  double magnitude() const { return std::sqrt(x * x + y * y + z * z); }
+
+  Vector rotate(double mu, double phi) const {
+    if (mu < -1.)
+      mu = -1.;
+    else if (mu > 1.)
+      mu = 1.;
+
+    if (phi < 0.)
+      phi = 0.;
+    else if (phi > 2. * PI)
+      phi = 2. * PI;
+
+    double xo, yo, zo;
+    const double c = std::cos(phi);
+    const double s = std::sin(phi);
+    const double C = std::sqrt(1. - mu * mu);
+
+    if (std::abs(1. - z * z) > 1.E-10) {
+      const double denom = std::sqrt(1. - z * z);
+
+      xo = x * mu + C * (c * x * z - s * y) / denom;
+      yo = y * mu + C * (c * y * z + s * x) / denom;
+      zo = z * mu - c * C * denom;
+    } else {
+      const double denom = std::sqrt(1. - y * y);
+
+      xo = x * mu + C * (c * x * y + s * z) / denom;
+      yo = y * mu - c * C * denom;
+      zo = z * mu + C * (c * y * z - s * x) / denom;
+    }
+
+    return {xo, yo, zo};
+  }
+};
+}  // namespace pndl
+
+#endif


### PR DESCRIPTION
This PR adds a new angle-energy distribution called `ElasticSVT`. This class implements the sampling of velocity of target algorithm for performing elastic scattering. This method is also often referred to as the constant cross section approximation. The user must provide the AWR of the nuclide, and the temperature at construction. A threshold must also be specified for using the target at rest approximation. Currently, this implementation does not allow use of the target at rest approximation for H1, but I might change this before merging.