### PR TITLE
Adds DBRC for elastic scattering

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ set(PNDL_SOURCE_LIST src/element.cpp
                      src/cm_distribution.cpp
                      src/svt.cpp
                      src/elastic_svt.cpp
+                     src/elastic_dbrc.cpp
                      src/energy_grid.cpp
                      src/cross_section.cpp
                      src/delayed_group.cpp

--- a/docs/api/angle_energy.rst
+++ b/docs/api/angle_energy.rst
@@ -73,3 +73,8 @@ ElasticSVT
 ----------
 
 .. doxygenclass:: pndl::ElasticSVT
+
+ElasticDBRC
+-----------
+
+.. doxygenclass:: pndl::ElasticDBRC

--- a/include/PapillonNDL/elastic_dbrc.hpp
+++ b/include/PapillonNDL/elastic_dbrc.hpp
@@ -1,0 +1,133 @@
+/*
+ * Papillon Nuclear Data Library
+ * Copyright 2021, Hunter Belanger
+ *
+ * hunter.belanger@gmail.com
+ *
+ * This file is part of the Papillon Nuclear Data Library (PapillonNDL).
+ *
+ * PapillonNDL is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PapillonNDL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PapillonNDL. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * */
+#ifndef PAPILLON_NDL_ELASTIC_DBRC_H
+#define PAPILLON_NDL_ELASTIC_DBRC_H
+
+#include <PapillonNDL/angle_distribution.hpp>
+#include <PapillonNDL/angle_energy.hpp>
+#include <PapillonNDL/cross_section.hpp>
+#include <functional>
+#include <optional>
+
+/**
+ * @file
+ * @author Hunter Belanger
+ */
+
+namespace pndl {
+
+/**
+ * @brief This class is used to sample elastic scattering of neutrons off of a
+ *        nuclide. It uses the Doppler Broadening Resonance Correcction
+ *        algorithm. It is an improvement on the constant cross section (CXS)
+ *        approximation, and provided an exact treatment for the elastic
+ *        scattering of neutrons off of nuclides which exhibit strong resonance
+ *        behavior at low energies.
+ *
+ *        At certain energies, it becomes reasonable to make the approximation
+ *        that the target nuclide is at rest, and has no thermal motion. The
+ *        threshold for applying this approximation is set with the
+ *        tar_threshold parameter. If the incident energy of the neutron (Ein)
+ *        is larger than tar_threshold * temperature * k (where k is the
+ *        Boltzmann constant), then the target is taken to be stationary. One
+ *        exception to this rule is for nuclides with an AWR < 1 (only H1).
+ *        Since H1 is actually has a slightly smaller mass than a neutron, the
+ *        target at rest approximation is generally inadequate.
+ */
+class ElasticDBRC : public AngleEnergy {
+ public:
+  /**
+   * @param xs The 0 Kelvin elastic scattering cross section for the nuclide.
+   * @param angle The AngleDistribution for elastic scattering. This
+   *              distribution must be given in the center of mass frame.
+   * @param awr Atomic weight ratio of the nuclide.
+   * @param temperature Temperature in Kelvin of the nuclide.
+   * @param use_tar Flag for using the Target At Rest approximation. Default
+   *                value is true.
+   * @param tar_threshold The threshold for applying the Target At Rest
+   *                      approximation. Default value is 400.
+   */
+  ElasticDBRC(const CrossSection& xs, const AngleDistribution& angle,
+              double awr, double temperature, bool use_tar = true,
+              double tar_threshold = 400.);
+
+  AngleEnergyPacket sample_angle_energy(
+      double E_in, std::function<double()> rng) const override final;
+
+  std::optional<double> angle_pdf(double /*E_in*/,
+                                  double /*mu*/) const override final {
+    return std::nullopt;
+  }
+
+  std::optional<double> pdf(double /*E_in*/, double /*mu*/,
+                            double /*E_out*/) const override final {
+    return std::nullopt;
+  }
+
+  /**
+   * @brief Returns the AngleDistribution which describes the distribution for
+   *        the cosine of the scattering angle in the center-of-mass frame.
+   */
+  const AngleDistribution& angle_distribution() const { return angle_; }
+
+  /**
+   * @brief Returns the 0 Kelvin elastic scattering cross section for the
+   *        nuclide.
+   */
+  const CrossSection& elastic_0K_xs() const { return xs_; }
+
+  /**
+   * @breif Returns the Atomic Weight Ratio for the nuclide.
+   */
+  double awr() const { return awr_; }
+
+  /**
+   * @breif Returns the temperature for the nuclide in Kelvin.
+   */
+  double temperature() const;
+
+  /**
+   * @brief If true, the Target At Rest approximation is used for incident
+   *        energies which are larger than tar_threshold * kT. If false, the
+   *        Target At Rest approximation is never used.
+   */
+  bool use_tar() const { return use_tar_; };
+
+  /**
+   * @brief Returns the threshold for the application of the Target At Rest
+   *        approximation.
+   */
+  double tar_threshold() const { return tar_threshold_; }
+
+ private:
+  CrossSection xs_;
+  AngleDistribution angle_;
+  double awr_;
+  double kT_;  // Temperature in MeV
+  bool use_tar_;
+  double tar_threshold_;
+};
+
+}  // namespace pndl
+
+#endif

--- a/src/elastic_dbrc.cpp
+++ b/src/elastic_dbrc.cpp
@@ -1,0 +1,178 @@
+/*
+ * Papillon Nuclear Data Library
+ * Copyright 2021, Hunter Belanger
+ *
+ * hunter.belanger@gmail.com
+ *
+ * This file is part of the Papillon Nuclear Data Library (PapillonNDL).
+ *
+ * PapillonNDL is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PapillonNDL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PapillonNDL. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * */
+
+#include <PapillonNDL/elastic_dbrc.hpp>
+#include <PapillonNDL/pndl_exception.hpp>
+#include <cmath>
+#include <functional>
+
+#include "constants.hpp"
+#include "svt.hpp"
+#include "vector.hpp"
+
+namespace pndl {
+
+ElasticDBRC::ElasticDBRC(const CrossSection& xs, const AngleDistribution& angle,
+                         double awr, double temperature, bool use_tar,
+                         double tar_threshold)
+    : xs_(xs),
+      angle_(angle),
+      awr_(awr),
+      kT_(temperature * K_TO_EV * EV_TO_MEV),
+      use_tar_(use_tar),
+      tar_threshold_(tar_threshold) {
+  if (awr_ <= 0.) {
+    std::string mssg = "Atomic weight ratio must be greater than zero.";
+    throw PNDLException(mssg);
+  }
+
+  if (kT_ < 0.) {
+    std::string mssg = "Temperature must be greater than or equal to zero.";
+    throw PNDLException(mssg);
+  }
+
+  if (tar_threshold_ < 0.) {
+    std::string mssg =
+        "Target At Rest threshold must be greater than or equal to zero.";
+    throw PNDLException(mssg);
+  }
+
+  if (use_tar_ == false) tar_threshold_ = INF;
+}
+
+double ElasticDBRC::temperature() const { return kT_ * MEV_TO_EV * EV_TO_K; }
+
+double find_max_xs_value(const CrossSection& xs, const double& Emin,
+                         const double& Emax) {
+  const std::size_t i_min = xs.energy_grid().get_lower_index(Emin);
+  // const double xs_Emin = xs(Emin, i_min);
+  const double xs_Emin = xs(Emin);
+  const std::size_t i_max = xs.energy_grid().get_lower_index(Emax);
+  // const double xs_Emax = xs(Emax, i_max);
+  const double xs_Emax = xs(Emax);
+  double xs_max = std::max(xs_Emin, xs_Emax);
+
+  for (std::size_t i = i_min + 1; i <= i_max; i++) {
+    if (xs.xs()[i] > xs_max) xs_max = xs.xs()[i];
+  }
+
+  return xs_max;
+}
+
+Vector sample_target_velocity_dbrc(const double& Ein, const CrossSection& xs,
+                                   const double& kT, const double& awr,
+                                   const std::function<double()>& rng) {
+  // Get min and max energies for finding the max, based on incident energy
+  const Vector v_n(0., 0., std::sqrt(Ein));
+  const double y = std::sqrt(awr * Ein / kT);
+  const double y_min = std::max(0., y - 4.);
+  const double Er_min = y_min * y_min * kT / awr;
+  const double y_max = y + 4.;
+  const double Er_max = y_max * y_max * kT / awr;
+  const double xs_max = find_max_xs_value(xs, Er_min, Er_max);
+
+  Vector v_t(0., 0., 0.);
+  bool sample_velocity = true;
+  while (sample_velocity) {
+    v_t = sample_target_velocity(Ein, kT, awr, rng);
+
+    const Vector vr = v_n - v_t;
+    const double Er = vr.dot(vr);
+
+    if (Er < Er_min || Er > Er_max) continue;
+
+    const std::size_t i_Er = xs.energy_grid().get_lower_index(Er);
+    const double xs_Er = xs(Er, i_Er);
+
+    if (rng() * xs_max < xs_Er) {
+      sample_velocity = false;
+    }
+  }
+
+  return v_t;
+}
+
+AngleEnergyPacket ElasticDBRC::sample_angle_energy(
+    double E_in, std::function<double()> rng) const {
+  // Direction in
+  const Vector u_n(0., 0., 1.);
+
+  // Get the "velocity" of the incident neutron in the lab frame
+  const Vector v_n = u_n * std::sqrt(E_in);
+
+  // Get the "velocity" of the target nuclide
+  const bool TAR = (use_tar_ && E_in >= tar_threshold_ * kT_) ? true : false;
+  const Vector v_t =
+      TAR ? Vector(0., 0., 0.)
+          : sample_target_velocity_dbrc(E_in, xs_, kT_, awr_, rng);
+
+  // Calculate the "velocity" of the center of mass.
+  const Vector v_cm = (v_n + (v_t * awr_)) / (awr_ + 1.);
+
+  // Calculate the "velocity" of the neutron in the CM frame
+  const Vector V_n = v_n - v_cm;
+
+  // Calculate the "speed" in the CM frame
+  const double S_n = V_n.magnitude();
+
+  // Calculate direction in the CM frame
+  const Vector U_n = V_n / S_n;
+
+  // Sample the scattering angle in the CM frame
+  const double mu_cm = angle_.sample_angle(E_in, rng);
+
+  // Get the outgoing velocity in the CM frame
+  const Vector V_n_out = U_n.rotate(mu_cm, 2. * PI * rng()) * S_n;
+
+  // Get the outgoing velocity in the LAB frame
+  const Vector v_n_out = V_n_out + v_cm;
+
+  // Calculate "speed" in the LAB frame
+  const double s_n_out = v_n_out.magnitude();
+
+  // Calculate direction in the LAB frrame
+  const Vector u_n_out = v_n_out / s_n_out;
+
+  // Calculate outgoing energy in LAB frame
+  const double E_out = s_n_out * s_n_out;
+
+  // Calculate the cosine of the scattering angle in the LAB frame
+  const double mu_lab = u_n.dot(u_n_out);
+
+  return {mu_lab, E_out};
+}
+
+}  // namespace pndl
+
+/*
+ * REFERENCES
+ *
+ * [1] R. R. Coveyou, R. R. Bate, and R. K. Osborn, “Effect of moderator
+ * temperature upon neutron flux in infinite, capturing medium,” J Nucl Energy
+ * 1954, vol. 2, no. 3–4, pp. 153–167, 1956, doi: 10.1016/0891-3919(55)90030-9.
+ *
+ * [2] P. K. Romano and J. A. Walsh, “An improved target velocity sampling
+ * algorithm for free gas elastic scattering,” Ann Nucl Energy, vol. 114, no.
+ * Ann.  Nucl. Energy 36 2009, pp. 318–324, 2018,
+ * doi: 10.1016/j.anucene.2017.12.044.
+ */

--- a/src/python/angle_energy.cpp
+++ b/src/python/angle_energy.cpp
@@ -30,6 +30,7 @@
 #include <PapillonNDL/cm_distribution.hpp>
 #include <PapillonNDL/continuous_energy_discrete_cosines.hpp>
 #include <PapillonNDL/discrete_cosines_energies.hpp>
+#include <PapillonNDL/elastic_dbrc.hpp>
 #include <PapillonNDL/elastic_svt.hpp>
 #include <PapillonNDL/energy_angle_table.hpp>
 #include <PapillonNDL/kalbach.hpp>
@@ -302,8 +303,28 @@ void init_ElasticSVT(py::module& m) {
       .def("sample_angle_energy", &ElasticSVT::sample_angle_energy)
       .def("angle_pdf", &ElasticSVT::angle_pdf)
       .def("pdf", &ElasticSVT::pdf)
+      .def("angle_distribution", &ElasticSVT::angle_distribution)
       .def("awr", &ElasticSVT::awr)
       .def("use_tar", &ElasticSVT::use_tar)
       .def("tar_threshold", &ElasticSVT::tar_threshold)
       .def("temperature", &ElasticSVT::temperature);
+}
+
+void init_ElasticDBRC(py::module& m) {
+  py::class_<ElasticDBRC, AngleEnergy, std::shared_ptr<ElasticDBRC>>(
+      m, "ElasticDBRC")
+      .def(py::init<const CrossSection&, const AngleDistribution&, double,
+                    double, bool, double>(),
+           py::arg("xs"), py::arg("angle"), py::arg("awr"),
+           py::arg("temperature"), py::arg("use_tar") = true,
+           py::arg("tar_threshold") = 400.)
+      .def("sample_angle_energy", &ElasticDBRC::sample_angle_energy)
+      .def("angle_pdf", &ElasticDBRC::angle_pdf)
+      .def("pdf", &ElasticDBRC::pdf)
+      .def("elastic_0K_xs", &ElasticDBRC::elastic_0K_xs)
+      .def("angle_distribution", &ElasticDBRC::angle_distribution)
+      .def("awr", &ElasticDBRC::awr)
+      .def("use_tar", &ElasticDBRC::use_tar)
+      .def("tar_threshold", &ElasticDBRC::tar_threshold)
+      .def("temperature", &ElasticDBRC::temperature);
 }

--- a/src/python/pyPapillonNDL.cpp
+++ b/src/python/pyPapillonNDL.cpp
@@ -57,6 +57,7 @@ extern void init_AngleEnergyPacket(py::module&);
 extern void init_AngleEnergy(py::module&);
 extern void init_Uncorrelated(py::module&);
 extern void init_ElasticSVT(py::module&);
+extern void init_ElasticDBRC(py::module&);
 extern void init_NBody(py::module&);
 extern void init_KalbachTable(py::module&);
 extern void init_Kalbach(py::module&);
@@ -121,6 +122,7 @@ PYBIND11_MODULE(pyPapillonNDL, m) {
   init_AngleEnergy(m);
   init_Uncorrelated(m);
   init_ElasticSVT(m);
+  init_ElasticDBRC(m);
   init_NBody(m);
   init_KalbachTable(m);
   init_Kalbach(m);

--- a/src/svt.cpp
+++ b/src/svt.cpp
@@ -23,6 +23,8 @@
 
 #include "svt.hpp"
 
+#include <cmath>
+
 namespace pndl {
 
 Vector sample_target_velocity(const double& Ein, const double& kT,


### PR DESCRIPTION
This PR adds an `ElasticDBRC` class, which samples the elastic scattering kernel with the exact Doppler Broadening Rejection Correction method, which properly handles elastic scattering off of heavy resonant nuclides. This class should be used over `ElasticSVT` for large resonant nuclides such as U238.