### PR TITLE
Adds STReaction for elastic scattering MT = 2

### DIFF
--- a/include/PapillonNDL/ce_neutron.hpp
+++ b/include/PapillonNDL/ce_neutron.hpp
@@ -32,6 +32,8 @@
 #include <PapillonNDL/reaction.hpp>
 #include <PapillonNDL/urr_ptables.hpp>
 
+#include "PapillonNDL/cross_section.hpp"
+
 namespace pndl {
 
 template <typename XSType>
@@ -122,6 +124,40 @@ class CENeutron<CrossSection> : public CENeutronBase {
    * @brief Returns a reference to the URRPTables instance.
    */
   const URRPTables& urr_ptables() const { return *urr_ptables_; }
+
+  /**
+   * @brief Sets elastic scattering to use the Sample Velocity of Target
+   * algorithm.
+   * @param use_tar Flag for using the Target At Rest approximation. Default
+   *                value is true.
+   * @param tar_threshold The threshold for applying the Target At Rest
+   *                      approximation. Default value is 400.
+   */
+  void use_SVT(bool use_tar = true, double tar_threshold = 400.);
+
+  /**
+   * @brief Sets elastic scattering to use the Doppler Broadening Resonance
+   * Correction algorithm.
+   * @param xs The 0 Kelvin elastic scattering cross section for the nuclide.
+   * @param use_tar Flag for using the Target At Rest approximation. Default
+   *                value is true.
+   * @param tar_threshold The threshold for applying the Target At Rest
+   *                      approximation. Default value is 400.
+   */
+  void use_DBRC(const CrossSection& xs, bool use_tar = true,
+                double tar_threshold = 400.);
+
+  /**
+   * @brief Returns true if the STNeutron instance is using ElasticSVT for an
+   *        elastic scattering distribution.
+   */
+  bool using_SVT() const;
+
+  /**
+   * @brief Returns true if the STNeutron instance is using ElasticDBRC for an
+   *        elastic scattering distribution.
+   */
+  bool using_DBRC() const;
 
  private:
   double temperature_;

--- a/include/PapillonNDL/reaction.hpp
+++ b/include/PapillonNDL/reaction.hpp
@@ -73,6 +73,9 @@ class Reaction<CrossSection> : public ReactionBase {
            double threshold, std::shared_ptr<Function1D> yield,
            std::shared_ptr<AngleEnergy> neutron_distribution);
 
+  Reaction(const Reaction&) = default;
+  Reaction& operator=(const Reaction&) = default;
+
   /**
    * @brief Returns the CrossSection for the reaction.
    */

--- a/include/PapillonNDL/reaction_base.hpp
+++ b/include/PapillonNDL/reaction_base.hpp
@@ -45,6 +45,7 @@ namespace pndl {
 class ReactionBase {
  public:
   ReactionBase(const ReactionBase&) = default;
+  ReactionBase& operator=(const ReactionBase&) = default;
 
   /**
    * @brief Returns the MT of the reaction.

--- a/src/python/ce_neutron.cpp
+++ b/src/python/ce_neutron.cpp
@@ -65,5 +65,9 @@ void init_STNeutron(py::module& m) {
       .def("disappearance_xs", &STNeutron::disappearance_xs)
       .def("photon_production_xs", &STNeutron::photon_production_xs)
       .def("reaction", &STNeutron::reaction)
-      .def("urr_ptables", &STNeutron::urr_ptables);
+      .def("urr_ptables", &STNeutron::urr_ptables)
+      .def("use_SVT", &STNeutron::use_SVT)
+      .def("use_DBRC", &STNeutron::use_DBRC)
+      .def("using_SVT", &STNeutron::using_SVT)
+      .def("using_DBRC", &STNeutron::using_DBRC);
 }


### PR DESCRIPTION
This PR adds a new feature where when an `STNeutron` instance is constructed, it will now also create an `STReaction` for elastic scattering (MT=2). When constructing `STNeutron` from just an `ACE`, `ElasticSVT` will always be used, with Target At Rest (TAR) enabled above 400kT (regardless of the AWR of the nuclide).

If constructing an `STNeutron` instance from an `ACE` and another `STNeutron` instance at a different temperature, we will then copy the same type of elastic distribution as provided in the pre-existing `STNeutron` object, with the same TAR parameters.

The elastic scattering distribution can be changed after construction using the new `STNeutron::use_SVT` and `STNeutron::use_DBRC` methods.

I have also added two methods which can probe whether a nuclide uses SVT or DBRC (`STNeutron::using_SVT` and `STNeutron::using_DBRC` respectively). I am not sure if these will remain however; I might make them private, or remove them all together.