### PR TITLE
Prepare v0.3.0

### DIFF
--- a/include/PapillonNDL/absorption.hpp
+++ b/include/PapillonNDL/absorption.hpp
@@ -44,7 +44,7 @@ class Absorption : public AngleEnergy {
   Absorption(uint32_t mt) : mt_(mt) {}
 
   AngleEnergyPacket sample_angle_energy(
-      double /*E_in*/, std::function<double()> /*rng*/) const override final {
+      double /*E_in*/, const std::function<double()>& /*rng*/) const override final {
     std::string mssg =
         "Distribution for MT " + std::to_string(mt_) + " is absorption.";
     throw PNDLException(mssg);

--- a/include/PapillonNDL/absorption.hpp
+++ b/include/PapillonNDL/absorption.hpp
@@ -44,7 +44,8 @@ class Absorption : public AngleEnergy {
   Absorption(uint32_t mt) : mt_(mt) {}
 
   AngleEnergyPacket sample_angle_energy(
-      double /*E_in*/, const std::function<double()>& /*rng*/) const override final {
+      double /*E_in*/,
+      const std::function<double()>& /*rng*/) const override final {
     std::string mssg =
         "Distribution for MT " + std::to_string(mt_) + " is absorption.";
     throw PNDLException(mssg);

--- a/include/PapillonNDL/absorption.hpp
+++ b/include/PapillonNDL/absorption.hpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/include/PapillonNDL/ace.hpp
+++ b/include/PapillonNDL/ace.hpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/include/PapillonNDL/angle_distribution.hpp
+++ b/include/PapillonNDL/angle_distribution.hpp
@@ -62,7 +62,7 @@ class AngleDistribution {
    * @param E_in Incident energy before scatter, in MeV.
    * @param rng Random number generator function.
    */
-  double sample_angle(double E_in, std::function<double()> rng) const;
+  double sample_angle(double E_in, const std::function<double()>& rng) const;
 
   /**
    * @brief Evaluates the PDF for having a scattering cosine of mu at incoming

--- a/include/PapillonNDL/angle_distribution.hpp
+++ b/include/PapillonNDL/angle_distribution.hpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/include/PapillonNDL/angle_energy.hpp
+++ b/include/PapillonNDL/angle_energy.hpp
@@ -57,7 +57,7 @@ class AngleEnergy : public std::enable_shared_from_this<AngleEnergy> {
    *         AngleEnergyPacket.
    */
   virtual AngleEnergyPacket sample_angle_energy(
-      double E_in, std::function<double()> rng) const = 0;
+      double E_in, const std::function<double()>& rng) const = 0;
 
   /**
    * @brief Evaluates the marginal PDF for having a scattering cosine of mu at

--- a/include/PapillonNDL/angle_energy.hpp
+++ b/include/PapillonNDL/angle_energy.hpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/include/PapillonNDL/angle_law.hpp
+++ b/include/PapillonNDL/angle_law.hpp
@@ -45,7 +45,7 @@ class AngleLaw : public std::enable_shared_from_this<AngleLaw> {
    * @param xi Random variable from the interval [0,1).
    * @param rng Random number generator function.
    */
-  virtual double sample_mu(std::function<double()> rng) const = 0;
+  virtual double sample_mu(const std::function<double()>& rng) const = 0;
 
   /**
    * @brief Returns the PDF for the desired scattering cosine.

--- a/include/PapillonNDL/angle_law.hpp
+++ b/include/PapillonNDL/angle_law.hpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/include/PapillonNDL/angle_table.hpp
+++ b/include/PapillonNDL/angle_table.hpp
@@ -69,7 +69,7 @@ class AngleTable : public AngleLaw {
   AngleTable(const PCTable& table);
   ~AngleTable() = default;
 
-  double sample_mu(std::function<double()> rng) const override final;
+  double sample_mu(const std::function<double()>& rng) const override final;
 
   double pdf(double mu) const override final { return distribution_.pdf(mu); }
 

--- a/include/PapillonNDL/angle_table.hpp
+++ b/include/PapillonNDL/angle_table.hpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/include/PapillonNDL/cm_distribution.hpp
+++ b/include/PapillonNDL/cm_distribution.hpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/include/PapillonNDL/cm_distribution.hpp
+++ b/include/PapillonNDL/cm_distribution.hpp
@@ -52,7 +52,7 @@ class CMDistribution : public AngleEnergy {
       : awr_(A), q_(Q), distribution_(distribution) {}
 
   AngleEnergyPacket sample_angle_energy(
-      double E_in, std::function<double()> rng) const override final;
+      double E_in, const std::function<double()>& rng) const override final;
 
   std::optional<double> angle_pdf(double E_in, double mu) const override final;
 

--- a/include/PapillonNDL/constant.hpp
+++ b/include/PapillonNDL/constant.hpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/include/PapillonNDL/continuous_energy_discrete_cosines.hpp
+++ b/include/PapillonNDL/continuous_energy_discrete_cosines.hpp
@@ -72,7 +72,7 @@ class ContinuousEnergyDiscreteCosines : public AngleEnergy {
   };
 
   AngleEnergyPacket sample_angle_energy(
-      double E_in, std::function<double()> rng) const override final;
+      double E_in, const std::function<double()>& rng) const override final;
 
   std::optional<double> angle_pdf(double E_in, double mu) const override final;
 
@@ -116,9 +116,9 @@ class ContinuousEnergyDiscreteCosines : public AngleEnergy {
   bool unit_based_interpolation_;
 
   AngleEnergyPacket sample_with_unit_based_interpolation(
-      double E_in, std::function<double()> rng) const;
+      double E_in, const std::function<double()>& rng) const;
   AngleEnergyPacket sample_without_unit_based_interpolation(
-      double E_in, std::function<double()> rng) const;
+      double E_in, const std::function<double()>& rng) const;
 };
 
 }  // namespace pndl

--- a/include/PapillonNDL/continuous_energy_discrete_cosines.hpp
+++ b/include/PapillonNDL/continuous_energy_discrete_cosines.hpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/include/PapillonNDL/cross_section.hpp
+++ b/include/PapillonNDL/cross_section.hpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/include/PapillonNDL/delayed_family.hpp
+++ b/include/PapillonNDL/delayed_family.hpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/include/PapillonNDL/difference_1d.hpp
+++ b/include/PapillonNDL/difference_1d.hpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/include/PapillonNDL/discrete_cosines_energies.hpp
+++ b/include/PapillonNDL/discrete_cosines_energies.hpp
@@ -54,7 +54,7 @@ class DiscreteCosinesEnergies : public AngleEnergy {
   };
 
   AngleEnergyPacket sample_angle_energy(
-      double E_in, std::function<double()> rng) const override final;
+      double E_in, const std::function<double()>& rng) const override final;
 
   std::optional<double> angle_pdf(double E_in, double mu) const override final;
 

--- a/include/PapillonNDL/discrete_cosines_energies.hpp
+++ b/include/PapillonNDL/discrete_cosines_energies.hpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/include/PapillonNDL/discrete_photon.hpp
+++ b/include/PapillonNDL/discrete_photon.hpp
@@ -94,7 +94,7 @@ class DiscretePhoton : public EnergyLaw {
   ~DiscretePhoton() = default;
 
   double sample_energy(double E_in,
-                       std::function<double()> /*rng*/) const override final {
+                       const std::function<double()>& /*rng*/) const override final {
     if ((lp == 0) || (lp == 1)) return Eg;
     return Eg + (A / (A + 1.)) * E_in;
   }

--- a/include/PapillonNDL/discrete_photon.hpp
+++ b/include/PapillonNDL/discrete_photon.hpp
@@ -93,8 +93,8 @@ class DiscretePhoton : public EnergyLaw {
 
   ~DiscretePhoton() = default;
 
-  double sample_energy(double E_in,
-                       const std::function<double()>& /*rng*/) const override final {
+  double sample_energy(double E_in, const std::function<double()>& /*rng*/)
+      const override final {
     if ((lp == 0) || (lp == 1)) return Eg;
     return Eg + (A / (A + 1.)) * E_in;
   }

--- a/include/PapillonNDL/discrete_photon.hpp
+++ b/include/PapillonNDL/discrete_photon.hpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/include/PapillonNDL/elastic.hpp
+++ b/include/PapillonNDL/elastic.hpp
@@ -68,7 +68,7 @@ class Elastic : public AngleEnergy {
           bool use_tar = true, double tar_threshold = 400.);
 
   AngleEnergyPacket sample_angle_energy(
-      double E_in, std::function<double()> rng) const override final;
+      double E_in, const std::function<double()>& rng) const override final;
 
   std::optional<double> angle_pdf(double /*E_in*/,
                                   double /*mu*/) const override final {

--- a/include/PapillonNDL/elastic.hpp
+++ b/include/PapillonNDL/elastic.hpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/include/PapillonNDL/elastic_dbrc.hpp
+++ b/include/PapillonNDL/elastic_dbrc.hpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/include/PapillonNDL/elastic_doppler_broadener.hpp
+++ b/include/PapillonNDL/elastic_doppler_broadener.hpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/include/PapillonNDL/elastic_svt.hpp
+++ b/include/PapillonNDL/elastic_svt.hpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/include/PapillonNDL/element.hpp
+++ b/include/PapillonNDL/element.hpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/include/PapillonNDL/energy_angle_table.hpp
+++ b/include/PapillonNDL/energy_angle_table.hpp
@@ -72,7 +72,7 @@ class EnergyAngleTable {
                    const std::vector<PCTable>& angle_tables);
   ~EnergyAngleTable() = default;
 
-  AngleEnergyPacket sample_angle_energy(std::function<double()> rng) const {
+  AngleEnergyPacket sample_angle_energy(const std::function<double()>& rng) const {
     double E_out, mu;
     double xi = rng();
     auto cdf_it = std::lower_bound(cdf_.begin(), cdf_.end(), xi);

--- a/include/PapillonNDL/energy_angle_table.hpp
+++ b/include/PapillonNDL/energy_angle_table.hpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/include/PapillonNDL/energy_angle_table.hpp
+++ b/include/PapillonNDL/energy_angle_table.hpp
@@ -72,7 +72,8 @@ class EnergyAngleTable {
                    const std::vector<PCTable>& angle_tables);
   ~EnergyAngleTable() = default;
 
-  AngleEnergyPacket sample_angle_energy(const std::function<double()>& rng) const {
+  AngleEnergyPacket sample_angle_energy(
+      const std::function<double()>& rng) const {
     double E_out, mu;
     double xi = rng();
     auto cdf_it = std::lower_bound(cdf_.begin(), cdf_.end(), xi);

--- a/include/PapillonNDL/energy_grid.hpp
+++ b/include/PapillonNDL/energy_grid.hpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/include/PapillonNDL/energy_law.hpp
+++ b/include/PapillonNDL/energy_law.hpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/include/PapillonNDL/energy_law.hpp
+++ b/include/PapillonNDL/energy_law.hpp
@@ -47,7 +47,7 @@ class EnergyLaw : public std::enable_shared_from_this<EnergyLaw> {
    * @param rng Random number generation function.
    */
   virtual double sample_energy(double E_in,
-                               std::function<double()> rng) const = 0;
+                               const std::function<double()>& rng) const = 0;
 
   /**
    * @brief Samples the PDF for the energy transfer from E_in to E_out where

--- a/include/PapillonNDL/equiprobable_angle_bins.hpp
+++ b/include/PapillonNDL/equiprobable_angle_bins.hpp
@@ -50,7 +50,7 @@ class EquiprobableAngleBins : public AngleLaw {
   EquiprobableAngleBins(const std::vector<double>& bounds);
   ~EquiprobableAngleBins() = default;
 
-  double sample_mu(std::function<double()> rng) const override final;
+  double sample_mu(const std::function<double()>& rng) const override final;
 
   double pdf(double mu) const override final;
 

--- a/include/PapillonNDL/equiprobable_angle_bins.hpp
+++ b/include/PapillonNDL/equiprobable_angle_bins.hpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/include/PapillonNDL/equiprobable_energy_bins.hpp
+++ b/include/PapillonNDL/equiprobable_energy_bins.hpp
@@ -55,7 +55,7 @@ class EquiprobableEnergyBins : public EnergyLaw {
   ~EquiprobableEnergyBins() = default;
 
   double sample_energy(double E_in,
-                       std::function<double()> rng) const override final;
+                       const std::function<double()>& rng) const override final;
 
   std::optional<double> pdf(double E_in, double E_out) const override final;
 

--- a/include/PapillonNDL/equiprobable_energy_bins.hpp
+++ b/include/PapillonNDL/equiprobable_energy_bins.hpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/include/PapillonNDL/evaporation.hpp
+++ b/include/PapillonNDL/evaporation.hpp
@@ -55,7 +55,7 @@ class Evaporation : public EnergyLaw {
   ~Evaporation() = default;
 
   double sample_energy(double E_in,
-                       std::function<double()> rng) const override final;
+                       const std::function<double()>& rng) const override final;
 
   std::optional<double> pdf(double E_in, double E_out) const override final;
 

--- a/include/PapillonNDL/evaporation.hpp
+++ b/include/PapillonNDL/evaporation.hpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/include/PapillonNDL/fission.hpp
+++ b/include/PapillonNDL/fission.hpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/include/PapillonNDL/frame.hpp
+++ b/include/PapillonNDL/frame.hpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/include/PapillonNDL/function_1d.hpp
+++ b/include/PapillonNDL/function_1d.hpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/include/PapillonNDL/general_evaporation.hpp
+++ b/include/PapillonNDL/general_evaporation.hpp
@@ -56,7 +56,7 @@ class GeneralEvaporation : public EnergyLaw {
   ~GeneralEvaporation() = default;
 
   double sample_energy(double E_in,
-                       std::function<double()> rng) const override final;
+                       const std::function<double()>& rng) const override final;
 
   std::optional<double> pdf(double E_in, double E_out) const override final;
 

--- a/include/PapillonNDL/general_evaporation.hpp
+++ b/include/PapillonNDL/general_evaporation.hpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/include/PapillonNDL/interpolation.hpp
+++ b/include/PapillonNDL/interpolation.hpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/include/PapillonNDL/isotope.hpp
+++ b/include/PapillonNDL/isotope.hpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/include/PapillonNDL/isotropic.hpp
+++ b/include/PapillonNDL/isotropic.hpp
@@ -42,7 +42,7 @@ class Isotropic : public AngleLaw {
   Isotropic() {}
   ~Isotropic() = default;
 
-  double sample_mu(std::function<double()> rng) const override final;
+  double sample_mu(const std::function<double()>& rng) const override final;
 
   double pdf(double mu) const override final;
 };

--- a/include/PapillonNDL/isotropic.hpp
+++ b/include/PapillonNDL/isotropic.hpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/include/PapillonNDL/kalbach.hpp
+++ b/include/PapillonNDL/kalbach.hpp
@@ -58,7 +58,7 @@ class Kalbach : public AngleEnergy {
   ~Kalbach() = default;
 
   AngleEnergyPacket sample_angle_energy(
-      double E_in, std::function<double()> rng) const override final;
+      double E_in, const std::function<double()>& rng) const override final;
 
   std::optional<double> angle_pdf(double E_in, double mu) const override final;
 

--- a/include/PapillonNDL/kalbach.hpp
+++ b/include/PapillonNDL/kalbach.hpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/include/PapillonNDL/kalbach_table.hpp
+++ b/include/PapillonNDL/kalbach_table.hpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/include/PapillonNDL/legendre.hpp
+++ b/include/PapillonNDL/legendre.hpp
@@ -53,7 +53,7 @@ class Legendre : public AngleLaw {
    */
   Legendre(const std::vector<double>& a);
 
-  double sample_mu(std::function<double()> rng) const override final;
+  double sample_mu(const std::function<double()>& rng) const override final;
 
   double pdf(double mu) const override final;
 

--- a/include/PapillonNDL/legendre.hpp
+++ b/include/PapillonNDL/legendre.hpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/include/PapillonNDL/level_inelastic_scatter.hpp
+++ b/include/PapillonNDL/level_inelastic_scatter.hpp
@@ -54,7 +54,7 @@ class LevelInelasticScatter : public EnergyLaw {
   ~LevelInelasticScatter() = default;
 
   double sample_energy(double E_in,
-                       std::function<double()> rng) const override final;
+                       const std::function<double()>& rng) const override final;
 
   std::optional<double> pdf(double E_in, double E_out) const override final;
 

--- a/include/PapillonNDL/level_inelastic_scatter.hpp
+++ b/include/PapillonNDL/level_inelastic_scatter.hpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/include/PapillonNDL/linearize.hpp
+++ b/include/PapillonNDL/linearize.hpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/include/PapillonNDL/maxwellian.hpp
+++ b/include/PapillonNDL/maxwellian.hpp
@@ -55,7 +55,7 @@ class Maxwellian : public EnergyLaw {
   ~Maxwellian() = default;
 
   double sample_energy(double E_in,
-                       std::function<double()> rng) const override final;
+                       const std::function<double()>& rng) const override final;
 
   std::optional<double> pdf(double E_in, double E_out) const override final;
 

--- a/include/PapillonNDL/maxwellian.hpp
+++ b/include/PapillonNDL/maxwellian.hpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/include/PapillonNDL/mcnp_library.hpp
+++ b/include/PapillonNDL/mcnp_library.hpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/include/PapillonNDL/multiple_distribution.hpp
+++ b/include/PapillonNDL/multiple_distribution.hpp
@@ -45,7 +45,7 @@ class MultipleDistribution : public AngleEnergy {
       const std::vector<std::shared_ptr<Tabulated1D>>& probabilities);
 
   AngleEnergyPacket sample_angle_energy(
-      double E_in, std::function<double()> rng) const override final;
+      double E_in, const std::function<double()>& rng) const override final;
 
   std::optional<double> angle_pdf(double E_in, double mu) const override final;
 

--- a/include/PapillonNDL/multiple_distribution.hpp
+++ b/include/PapillonNDL/multiple_distribution.hpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/include/PapillonNDL/nbody.hpp
+++ b/include/PapillonNDL/nbody.hpp
@@ -56,7 +56,7 @@ class NBody : public AngleEnergy {
   ~NBody() = default;
 
   AngleEnergyPacket sample_angle_energy(
-      double E_in, std::function<double()> rng) const override final;
+      double E_in, const std::function<double()>& rng) const override final;
 
   std::optional<double> angle_pdf(double E_in, double mu) const override final;
 
@@ -89,7 +89,7 @@ class NBody : public AngleEnergy {
   double A_;
   double Q_;
 
-  double maxwellian_spectrum(std::function<double()>& rng) const;
+  double maxwellian_spectrum(const std::function<double()>& rng) const;
 };
 
 }  // namespace pndl

--- a/include/PapillonNDL/nbody.hpp
+++ b/include/PapillonNDL/nbody.hpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/include/PapillonNDL/nd_library.hpp
+++ b/include/PapillonNDL/nd_library.hpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/include/PapillonNDL/nuclide.hpp
+++ b/include/PapillonNDL/nuclide.hpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/include/PapillonNDL/pctable.hpp
+++ b/include/PapillonNDL/pctable.hpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/include/PapillonNDL/pndl_exception.hpp
+++ b/include/PapillonNDL/pndl_exception.hpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/include/PapillonNDL/polynomial_1d.hpp
+++ b/include/PapillonNDL/polynomial_1d.hpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/include/PapillonNDL/reaction.hpp
+++ b/include/PapillonNDL/reaction.hpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/include/PapillonNDL/reaction_base.hpp
+++ b/include/PapillonNDL/reaction_base.hpp
@@ -73,7 +73,7 @@ class ReactionBase {
    * @param rng Random number generation function.
    */
   AngleEnergyPacket sample_neutron_angle_energy(
-      double E_in, std::function<double()> rng) const {
+      double E_in, const std::function<double()>& rng) const {
     if (E_in < threshold_) return {0., 0.};
 
     return neutron_distribution_->sample_angle_energy(E_in, rng);

--- a/include/PapillonNDL/reaction_base.hpp
+++ b/include/PapillonNDL/reaction_base.hpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/include/PapillonNDL/rng.hpp
+++ b/include/PapillonNDL/rng.hpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/include/PapillonNDL/serpent_library.hpp
+++ b/include/PapillonNDL/serpent_library.hpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/include/PapillonNDL/st_coherent_elastic.hpp
+++ b/include/PapillonNDL/st_coherent_elastic.hpp
@@ -65,7 +65,7 @@ class STCoherentElastic : public STTSLReaction {
   }
 
   AngleEnergyPacket sample_angle_energy(
-      double E_in, std::function<double()> rng) const override final {
+      double E_in, const std::function<double()>& rng) const override final {
     if (bragg_edges_.size() == 0) {
       std::string mssg =
           "Coherent elastic scattering is not possible. Cannot sample "

--- a/include/PapillonNDL/st_coherent_elastic.hpp
+++ b/include/PapillonNDL/st_coherent_elastic.hpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/include/PapillonNDL/st_incoherent_elastic_ace.hpp
+++ b/include/PapillonNDL/st_incoherent_elastic_ace.hpp
@@ -51,7 +51,7 @@ class STIncoherentElasticACE : public STTSLReaction {
   double xs(double E) const override final { return xs_->evaluate(E); }
 
   AngleEnergyPacket sample_angle_energy(
-      double E_in, std::function<double()> rng) const override final {
+      double E_in, const std::function<double()>& rng) const override final {
     if (incoming_energy_.size() == 0) {
       std::string mssg =
           "Incoherent elastic scattering is not possible. Cannot sample "

--- a/include/PapillonNDL/st_incoherent_elastic_ace.hpp
+++ b/include/PapillonNDL/st_incoherent_elastic_ace.hpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/include/PapillonNDL/st_incoherent_inelastic.hpp
+++ b/include/PapillonNDL/st_incoherent_inelastic.hpp
@@ -54,7 +54,7 @@ class STIncoherentInelastic : public STTSLReaction {
   double xs(double E) const override final { return xs_->evaluate(E); }
 
   AngleEnergyPacket sample_angle_energy(
-      double E_in, std::function<double()> rng) const override final {
+      double E_in, const std::function<double()>& rng) const override final {
     return angle_energy_->sample_angle_energy(E_in, rng);
   }
 

--- a/include/PapillonNDL/st_incoherent_inelastic.hpp
+++ b/include/PapillonNDL/st_incoherent_inelastic.hpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/include/PapillonNDL/st_neutron.hpp
+++ b/include/PapillonNDL/st_neutron.hpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/include/PapillonNDL/st_thermal_scattering_law.hpp
+++ b/include/PapillonNDL/st_thermal_scattering_law.hpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/include/PapillonNDL/st_tsl_reaction.hpp
+++ b/include/PapillonNDL/st_tsl_reaction.hpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/include/PapillonNDL/sum_1d.hpp
+++ b/include/PapillonNDL/sum_1d.hpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/include/PapillonNDL/summed_fission_spectrum.hpp
+++ b/include/PapillonNDL/summed_fission_spectrum.hpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/include/PapillonNDL/summed_fission_spectrum.hpp
+++ b/include/PapillonNDL/summed_fission_spectrum.hpp
@@ -59,7 +59,7 @@ class SummedFissionSpectrum : public AngleEnergy {
                         std::shared_ptr<STReaction> mt38);
 
   AngleEnergyPacket sample_angle_energy(
-      double E_in, std::function<double()> rng) const override final;
+      double E_in, const std::function<double()>& rng) const override final;
 
   std::optional<double> angle_pdf(double E_in, double mu) const override final;
 

--- a/include/PapillonNDL/tabular_energy.hpp
+++ b/include/PapillonNDL/tabular_energy.hpp
@@ -56,7 +56,7 @@ class TabularEnergy : public EnergyLaw {
   ~TabularEnergy() = default;
 
   double sample_energy(double E_in,
-                       std::function<double()> rng) const override final;
+                       const std::function<double()>& rng) const override final;
 
   std::optional<double> pdf(double E_in, double E_out) const override final;
 

--- a/include/PapillonNDL/tabular_energy.hpp
+++ b/include/PapillonNDL/tabular_energy.hpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/include/PapillonNDL/tabular_energy_angle.hpp
+++ b/include/PapillonNDL/tabular_energy_angle.hpp
@@ -57,7 +57,7 @@ class TabularEnergyAngle : public AngleEnergy {
   ~TabularEnergyAngle() = default;
 
   AngleEnergyPacket sample_angle_energy(
-      double E_in, std::function<double()> rng) const override final;
+      double E_in, const std::function<double()>& rng) const override final;
 
   std::optional<double> angle_pdf(double E_in, double mu) const override final;
 

--- a/include/PapillonNDL/tabular_energy_angle.hpp
+++ b/include/PapillonNDL/tabular_energy_angle.hpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/include/PapillonNDL/tabulated_1d.hpp
+++ b/include/PapillonNDL/tabulated_1d.hpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/include/PapillonNDL/uncorrelated.hpp
+++ b/include/PapillonNDL/uncorrelated.hpp
@@ -50,7 +50,7 @@ class Uncorrelated : public AngleEnergy {
   ~Uncorrelated() = default;
 
   AngleEnergyPacket sample_angle_energy(
-      double E_in, std::function<double()> rng) const override final;
+      double E_in, const std::function<double()>& rng) const override final;
 
   std::optional<double> angle_pdf(double E_in, double mu) const override final;
 

--- a/include/PapillonNDL/uncorrelated.hpp
+++ b/include/PapillonNDL/uncorrelated.hpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/include/PapillonNDL/urr_ptables.hpp
+++ b/include/PapillonNDL/urr_ptables.hpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/include/PapillonNDL/version.hpp
+++ b/include/PapillonNDL/version.hpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/include/PapillonNDL/watt.hpp
+++ b/include/PapillonNDL/watt.hpp
@@ -56,7 +56,7 @@ class Watt : public EnergyLaw {
   ~Watt() = default;
 
   double sample_energy(double E_in,
-                       std::function<double()> rng) const override final;
+                       const std::function<double()>& rng) const override final;
 
   std::optional<double> pdf(double E_in, double E_out) const override final;
 

--- a/include/PapillonNDL/watt.hpp
+++ b/include/PapillonNDL/watt.hpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/include/PapillonNDL/xs_packet.hpp
+++ b/include/PapillonNDL/xs_packet.hpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/include/PapillonNDL/zaid.hpp
+++ b/include/PapillonNDL/zaid.hpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/src/ace.cpp
+++ b/src/ace.cpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/src/angle_distribution.cpp
+++ b/src/angle_distribution.cpp
@@ -114,7 +114,7 @@ AngleDistribution::AngleDistribution(
 }
 
 double AngleDistribution::sample_angle(double E_in,
-                                       std::function<double()> rng) const {
+                                       const std::function<double()>& rng) const {
   auto E_it = std::lower_bound(energy_grid_.begin(), energy_grid_.end(), E_in);
   if (E_it == energy_grid_.begin())
     return laws_.front()->sample_mu(rng);

--- a/src/angle_distribution.cpp
+++ b/src/angle_distribution.cpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/src/angle_distribution.cpp
+++ b/src/angle_distribution.cpp
@@ -113,8 +113,8 @@ AngleDistribution::AngleDistribution(
   }
 }
 
-double AngleDistribution::sample_angle(double E_in,
-                                       const std::function<double()>& rng) const {
+double AngleDistribution::sample_angle(
+    double E_in, const std::function<double()>& rng) const {
   auto E_it = std::lower_bound(energy_grid_.begin(), energy_grid_.end(), E_in);
   if (E_it == energy_grid_.begin())
     return laws_.front()->sample_mu(rng);

--- a/src/angle_table.cpp
+++ b/src/angle_table.cpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/src/angle_table.cpp
+++ b/src/angle_table.cpp
@@ -112,7 +112,7 @@ AngleTable::AngleTable(const Legendre& legendre)
   }
 }
 
-double AngleTable::sample_mu(std::function<double()> rng) const {
+double AngleTable::sample_mu(const std::function<double()>& rng) const {
   double mu = distribution_.sample_value(rng());
   if (std::abs(mu) > 1.) mu = std::copysign(1., mu);
   return mu;

--- a/src/cm_distribution.cpp
+++ b/src/cm_distribution.cpp
@@ -31,7 +31,7 @@
 namespace pndl {
 
 AngleEnergyPacket CMDistribution::sample_angle_energy(
-    double E_in, std::function<double()> rng) const {
+    double E_in, const std::function<double()>& rng) const {
   AngleEnergyPacket out = distribution_->sample_angle_energy(E_in, rng);
 
   CMToLab::transform(E_in, awr_, out);

--- a/src/cm_distribution.cpp
+++ b/src/cm_distribution.cpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/src/constants.hpp
+++ b/src/constants.hpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/src/continuous_energy_discrete_cosines.cpp
+++ b/src/continuous_energy_discrete_cosines.cpp
@@ -212,7 +212,7 @@ ContinuousEnergyDiscreteCosines::ContinuousEnergyDiscreteCosines(
 }
 
 AngleEnergyPacket ContinuousEnergyDiscreteCosines::sample_angle_energy(
-    double E_in, std::function<double()> rng) const {
+    double E_in, const std::function<double()>& rng) const {
   if (!unit_based_interpolation_)
     return sample_without_unit_based_interpolation(E_in, rng);
   else
@@ -221,7 +221,7 @@ AngleEnergyPacket ContinuousEnergyDiscreteCosines::sample_angle_energy(
 
 AngleEnergyPacket
 ContinuousEnergyDiscreteCosines::sample_with_unit_based_interpolation(
-    double E_in, std::function<double()> rng) const {
+    double E_in, const std::function<double()>& rng) const {
   // First we sample the outgoing energy.
   // Determine the index of the bounding tabulated incoming energies
   std::size_t l;
@@ -303,7 +303,7 @@ ContinuousEnergyDiscreteCosines::sample_with_unit_based_interpolation(
 
 AngleEnergyPacket
 ContinuousEnergyDiscreteCosines::sample_without_unit_based_interpolation(
-    double E_in, std::function<double()> rng) const {
+    double E_in, const std::function<double()>& rng) const {
   // First we sample the outgoing energy.
   // Determine the index of the bounding tabulated incoming energies
   std::size_t l;

--- a/src/continuous_energy_discrete_cosines.cpp
+++ b/src/continuous_energy_discrete_cosines.cpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/src/cross_section.cpp
+++ b/src/cross_section.cpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/src/delayed_family.cpp
+++ b/src/delayed_family.cpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/src/discrete_cosines_energies.cpp
+++ b/src/discrete_cosines_energies.cpp
@@ -106,7 +106,7 @@ DiscreteCosinesEnergies::DiscreteCosinesEnergies(const ACE& ace)
 }
 
 AngleEnergyPacket DiscreteCosinesEnergies::sample_angle_energy(
-    double E_in, std::function<double()> rng) const {
+    double E_in, const std::function<double()>& rng) const {
   uint32_t j = 0;
   uint32_t k = static_cast<uint32_t>(Nmu * rng());
   // Sample j for the outgoing energy point

--- a/src/discrete_cosines_energies.cpp
+++ b/src/discrete_cosines_energies.cpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/src/elastic.cpp
+++ b/src/elastic.cpp
@@ -62,7 +62,7 @@ Elastic::Elastic(std::shared_ptr<ElasticDopplerBroadener> broadener,
 }
 
 AngleEnergyPacket Elastic::sample_angle_energy(
-    double E_in, std::function<double()> rng) const {
+    double E_in, const std::function<double()>& rng) const {
   // Direction in
   const Vector u_n(0., 0., 1.);
 

--- a/src/elastic.cpp
+++ b/src/elastic.cpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/src/elastic_dbrc.cpp
+++ b/src/elastic_dbrc.cpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/src/elastic_svt.cpp
+++ b/src/elastic_svt.cpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/src/element.cpp
+++ b/src/element.cpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/src/energy_angle_table.cpp
+++ b/src/energy_angle_table.cpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/src/energy_grid.cpp
+++ b/src/energy_grid.cpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/src/equiprobable_angle_bins.cpp
+++ b/src/equiprobable_angle_bins.cpp
@@ -77,7 +77,7 @@ EquiprobableAngleBins::EquiprobableAngleBins(const std::vector<double>& bounds)
   }
 }
 
-double EquiprobableAngleBins::sample_mu(std::function<double()> rng) const {
+double EquiprobableAngleBins::sample_mu(const std::function<double()>& rng) const {
   const double xi = rng();
   std::size_t bin =
       static_cast<std::size_t>(std::floor(static_cast<double>(NBOUNDS) * xi));

--- a/src/equiprobable_angle_bins.cpp
+++ b/src/equiprobable_angle_bins.cpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/src/equiprobable_angle_bins.cpp
+++ b/src/equiprobable_angle_bins.cpp
@@ -77,7 +77,8 @@ EquiprobableAngleBins::EquiprobableAngleBins(const std::vector<double>& bounds)
   }
 }
 
-double EquiprobableAngleBins::sample_mu(const std::function<double()>& rng) const {
+double EquiprobableAngleBins::sample_mu(
+    const std::function<double()>& rng) const {
   const double xi = rng();
   std::size_t bin =
       static_cast<std::size_t>(std::floor(static_cast<double>(NBOUNDS) * xi));

--- a/src/equiprobable_energy_bins.cpp
+++ b/src/equiprobable_energy_bins.cpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/src/equiprobable_energy_bins.cpp
+++ b/src/equiprobable_energy_bins.cpp
@@ -94,7 +94,7 @@ EquiprobableEnergyBins::EquiprobableEnergyBins(
 }
 
 double EquiprobableEnergyBins::sample_energy(
-    double E_in, std::function<double()> rng) const {
+    double E_in, const std::function<double()>& rng) const {
   // Determine the index of the bounding tabulated incoming energies
   auto in_E_it =
       std::lower_bound(incoming_energy_.begin(), incoming_energy_.end(), E_in);

--- a/src/evaporation.cpp
+++ b/src/evaporation.cpp
@@ -67,7 +67,7 @@ Evaporation::Evaporation(std::shared_ptr<Tabulated1D> temperature,
     : temperature_(temperature), restriction_energy_(restriction_energy) {}
 
 double Evaporation::sample_energy(double E_in,
-                                  std::function<double()> rng) const {
+                                  const std::function<double()>& rng) const {
   double T = (*temperature_)(E_in);
   double xi1 = 0.;
   double xi2 = 0.;

--- a/src/evaporation.cpp
+++ b/src/evaporation.cpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/src/fission.cpp
+++ b/src/fission.cpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/src/general_evaporation.cpp
+++ b/src/general_evaporation.cpp
@@ -82,8 +82,8 @@ GeneralEvaporation::GeneralEvaporation(std::shared_ptr<Tabulated1D> temperature,
   }
 }
 
-double GeneralEvaporation::sample_energy(double E_in,
-                                         const std::function<double()>& rng) const {
+double GeneralEvaporation::sample_energy(
+    double E_in, const std::function<double()>& rng) const {
   double T = (*temperature_)(E_in);
   double xi1 = rng();
   std::size_t bin =

--- a/src/general_evaporation.cpp
+++ b/src/general_evaporation.cpp
@@ -83,7 +83,7 @@ GeneralEvaporation::GeneralEvaporation(std::shared_ptr<Tabulated1D> temperature,
 }
 
 double GeneralEvaporation::sample_energy(double E_in,
-                                         std::function<double()> rng) const {
+                                         const std::function<double()>& rng) const {
   double T = (*temperature_)(E_in);
   double xi1 = rng();
   std::size_t bin =

--- a/src/general_evaporation.cpp
+++ b/src/general_evaporation.cpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/src/isotropic.cpp
+++ b/src/isotropic.cpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/src/isotropic.cpp
+++ b/src/isotropic.cpp
@@ -26,7 +26,7 @@
 
 namespace pndl {
 
-double Isotropic::sample_mu(std::function<double()> rng) const {
+double Isotropic::sample_mu(const std::function<double()>& rng) const {
   double mu = 2. * rng() - 1.;
   if (std::abs(mu) > 1.) mu = std::copysign(1., mu);
   return mu;

--- a/src/kalbach.cpp
+++ b/src/kalbach.cpp
@@ -79,7 +79,7 @@ Kalbach::Kalbach(const std::vector<double>& incoming_energy,
 }
 
 AngleEnergyPacket Kalbach::sample_angle_energy(
-    double E_in, std::function<double()> rng) const {
+    double E_in, const std::function<double()>& rng) const {
   // Determine the index of the bounding tabulated incoming energies
   std::size_t l;
   double f;  // Interpolation factor

--- a/src/kalbach.cpp
+++ b/src/kalbach.cpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/src/kalbach_table.cpp
+++ b/src/kalbach_table.cpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/src/legendre.cpp
+++ b/src/legendre.cpp
@@ -69,7 +69,7 @@ double Legendre::pdf(double mu) const {
   return pdf;
 }
 
-double Legendre::sample_mu(std::function<double()> rng) const {
+double Legendre::sample_mu(const std::function<double()>& rng) const {
   double mu = -2.;
 
   while (true) {

--- a/src/legendre.cpp
+++ b/src/legendre.cpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/src/level_inelastic_scatter.cpp
+++ b/src/level_inelastic_scatter.cpp
@@ -44,8 +44,8 @@ LevelInelasticScatter::LevelInelasticScatter(double Q, double AWR)
   C2_ = tmp * tmp;
 }
 
-double LevelInelasticScatter::sample_energy(double E_in,
-                                            const std::function<double()>&) const {
+double LevelInelasticScatter::sample_energy(
+    double E_in, const std::function<double()>&) const {
   return C2_ * (E_in - C1_);
 }
 

--- a/src/level_inelastic_scatter.cpp
+++ b/src/level_inelastic_scatter.cpp
@@ -45,7 +45,7 @@ LevelInelasticScatter::LevelInelasticScatter(double Q, double AWR)
 }
 
 double LevelInelasticScatter::sample_energy(double E_in,
-                                            std::function<double()>) const {
+                                            const std::function<double()>&) const {
   return C2_ * (E_in - C1_);
 }
 

--- a/src/level_inelastic_scatter.cpp
+++ b/src/level_inelastic_scatter.cpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/src/linearize.cpp
+++ b/src/linearize.cpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/src/maxwellian.cpp
+++ b/src/maxwellian.cpp
@@ -69,7 +69,7 @@ Maxwellian::Maxwellian(std::shared_ptr<Tabulated1D> temperature,
     : temperature_(temperature), restriction_energy_(restriction_energy) {}
 
 double Maxwellian::sample_energy(double E_in,
-                                 std::function<double()> rng) const {
+                                 const std::function<double()>& rng) const {
   double T = (*temperature_)(E_in);
   double xi1 = 0.;
   double xi2 = 0.;

--- a/src/maxwellian.cpp
+++ b/src/maxwellian.cpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/src/mcnp_library.cpp
+++ b/src/mcnp_library.cpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/src/multiple_distribution.cpp
+++ b/src/multiple_distribution.cpp
@@ -55,7 +55,7 @@ MultipleDistribution::MultipleDistribution(
 }
 
 AngleEnergyPacket MultipleDistribution::sample_angle_energy(
-    double E_in, std::function<double()> rng) const {
+    double E_in, const std::function<double()>& rng) const {
   // First select distribution
   double xi = rng();
   double sum = 0.;

--- a/src/multiple_distribution.cpp
+++ b/src/multiple_distribution.cpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/src/nbody.cpp
+++ b/src/nbody.cpp
@@ -78,7 +78,7 @@ NBody::NBody(uint16_t n, double Ap, double AWR, double Q)
 }
 
 AngleEnergyPacket NBody::sample_angle_energy(
-    double E_in, std::function<double()> rng) const {
+    double E_in, const std::function<double()>& rng) const {
   const double Emax = ((Ap_ - 1.) / Ap_) * ((A_ / (A_ + 1.)) * E_in + Q_);
   const double x = maxwellian_spectrum(rng);
   double y = 0.;
@@ -104,7 +104,7 @@ AngleEnergyPacket NBody::sample_angle_energy(
   return {mu, E_out};
 }
 
-double NBody::maxwellian_spectrum(std::function<double()>& rng) const {
+double NBody::maxwellian_spectrum(const std::function<double()>& rng) const {
   const double a = PI * rng() / 2.;
   return -(std::log(rng()) + std::log(rng()) * std::cos(a) * std::cos(a));
 }

--- a/src/nbody.cpp
+++ b/src/nbody.cpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/src/nd_library.cpp
+++ b/src/nd_library.cpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/src/pctable.cpp
+++ b/src/pctable.cpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/src/polynomial_1d.cpp
+++ b/src/polynomial_1d.cpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/src/python/ace.cpp
+++ b/src/python/ace.cpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/src/python/angle_distribution.cpp
+++ b/src/python/angle_distribution.cpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/src/python/angle_energy.cpp
+++ b/src/python/angle_energy.cpp
@@ -63,7 +63,7 @@ class PyAngleEnergy : public AngleEnergy {
   using AngleEnergy::AngleEnergy;
 
   AngleEnergyPacket sample_angle_energy(
-      double E_in, std::function<double()> rng) const override {
+      double E_in, const std::function<double()>& rng) const override {
     PYBIND11_OVERRIDE_PURE(AngleEnergyPacket, AngleEnergy, sample_angle_energy,
                            E_in, rng);
   }

--- a/src/python/angle_energy.cpp
+++ b/src/python/angle_energy.cpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/src/python/angle_law.cpp
+++ b/src/python/angle_law.cpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/src/python/angle_law.cpp
+++ b/src/python/angle_law.cpp
@@ -38,7 +38,7 @@ class PyAngleLaw : public AngleLaw {
  public:
   using AngleLaw::AngleLaw;
 
-  double sample_mu(std::function<double()> rng) const override {
+  double sample_mu(const std::function<double()>& rng) const override {
     PYBIND11_OVERRIDE_PURE(double, AngleLaw, sample_mu, rng);
   }
 

--- a/src/python/cross_section.cpp
+++ b/src/python/cross_section.cpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/src/python/delayed_family.cpp
+++ b/src/python/delayed_family.cpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/src/python/energy_grid.cpp
+++ b/src/python/energy_grid.cpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/src/python/energy_law.cpp
+++ b/src/python/energy_law.cpp
@@ -43,7 +43,7 @@ class PyEnergyLaw : public EnergyLaw {
   using EnergyLaw::EnergyLaw;
 
   double sample_energy(double E_in,
-                       std::function<double()> rng) const override {
+                       const std::function<double()>& rng) const override {
     PYBIND11_OVERRIDE_PURE(double, EnergyLaw, sample_energy, E_in, rng);
   }
 

--- a/src/python/energy_law.cpp
+++ b/src/python/energy_law.cpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/src/python/fission.cpp
+++ b/src/python/fission.cpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/src/python/frame.cpp
+++ b/src/python/frame.cpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/src/python/function_1d.cpp
+++ b/src/python/function_1d.cpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/src/python/interpolation.cpp
+++ b/src/python/interpolation.cpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/src/python/linearize.cpp
+++ b/src/python/linearize.cpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/src/python/nd_library.cpp
+++ b/src/python/nd_library.cpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/src/python/nuclide.cpp
+++ b/src/python/nuclide.cpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/src/python/pctable.cpp
+++ b/src/python/pctable.cpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/src/python/prng.cpp
+++ b/src/python/prng.cpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/src/python/pyPapillonNDL.cpp
+++ b/src/python/pyPapillonNDL.cpp
@@ -158,7 +158,7 @@ PYBIND11_MODULE(pyPapillonNDL, m) {
   init_SerpentLibrary(m);
 
   m.attr("__author__") = "Hunter Belanger";
-  m.attr("__copyright__") = "Copyright 2021, Hunter Belanger";
+  m.attr("__copyright__") = "Copyright 2021-2022, Hunter Belanger";
   m.attr("__license__") = "GPL-3.0-or-later";
   m.attr("__maintainer__") = "Hunter Belanger";
   m.attr("__email__") = "hunter.belanger@gmail.com";

--- a/src/python/pyPapillonNDL.cpp
+++ b/src/python/pyPapillonNDL.cpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/src/python/reaction.cpp
+++ b/src/python/reaction.cpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/src/python/st_neutron.cpp
+++ b/src/python/st_neutron.cpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/src/python/thermal_scattering.cpp
+++ b/src/python/thermal_scattering.cpp
@@ -45,7 +45,7 @@ class PySTTSLReaction : public STTSLReaction {
   }
 
   AngleEnergyPacket sample_angle_energy(
-      double E_in, std::function<double()> rng) const override {
+      double E_in, const std::function<double()>& rng) const override {
     PYBIND11_OVERRIDE_PURE(AngleEnergyPacket, STTSLReaction,
                            sample_angle_energy, E_in, rng);
   }

--- a/src/python/thermal_scattering.cpp
+++ b/src/python/thermal_scattering.cpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/src/python/urr_ptables.cpp
+++ b/src/python/urr_ptables.cpp
@@ -50,9 +50,9 @@ void init_URRPtable(py::module& m) {
                     const std::vector<STReaction>&>())
       .def("is_valid", &URRPTables::is_valid)
       .def("evaluate_xs", py::overload_cast<double, std::size_t, double>(
-                                   &URRPTables::evaluate_xs, py::const_))
+                              &URRPTables::evaluate_xs, py::const_))
       .def("evaluate_xs", py::overload_cast<double, double>(
-                                   &URRPTables::evaluate_xs, py::const_))
+                              &URRPTables::evaluate_xs, py::const_))
       .def("min_energy", &URRPTables::min_energy)
       .def("max_energy", &URRPTables::max_energy)
       .def("energy_in_range", &URRPTables::energy_in_range)

--- a/src/python/urr_ptables.cpp
+++ b/src/python/urr_ptables.cpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/src/python/xs_packet.cpp
+++ b/src/python/xs_packet.cpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/src/reaction.cpp
+++ b/src/reaction.cpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/src/reaction_base.cpp
+++ b/src/reaction_base.cpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/src/rng.cpp
+++ b/src/rng.cpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/src/serpent_library.cpp
+++ b/src/serpent_library.cpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/src/st_coherent_elastic.cpp
+++ b/src/st_coherent_elastic.cpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/src/st_incoherent_elastic_ace.cpp
+++ b/src/st_incoherent_elastic_ace.cpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/src/st_incoherent_inelastic.cpp
+++ b/src/st_incoherent_inelastic.cpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/src/st_neutron.cpp
+++ b/src/st_neutron.cpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/src/st_thermal_scattering_law.cpp
+++ b/src/st_thermal_scattering_law.cpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/src/summed_fission_spectrum.cpp
+++ b/src/summed_fission_spectrum.cpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/src/summed_fission_spectrum.cpp
+++ b/src/summed_fission_spectrum.cpp
@@ -69,7 +69,7 @@ inline void SummedFissionSpectrum::compute_probabilities(
 }
 
 AngleEnergyPacket SummedFissionSpectrum::sample_angle_energy(
-    double E_in, std::function<double()> rng) const {
+    double E_in, const std::function<double()>& rng) const {
   // Get probabilities
   std::array<double, 4> probs{0., 0., 0., 0.};
   this->compute_probabilities(probs, E_in);

--- a/src/tabular_energy.cpp
+++ b/src/tabular_energy.cpp
@@ -73,7 +73,7 @@ TabularEnergy::TabularEnergy(const std::vector<double>& incoming_energy,
 }
 
 double TabularEnergy::sample_energy(double E_in,
-                                    std::function<double()> rng) const {
+                                    const std::function<double()>& rng) const {
   // Determine the index of the bounding tabulated incoming energies
   std::size_t l;
   double f;  // Interpolation factor

--- a/src/tabular_energy.cpp
+++ b/src/tabular_energy.cpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/src/tabular_energy_angle.cpp
+++ b/src/tabular_energy_angle.cpp
@@ -81,7 +81,7 @@ TabularEnergyAngle::TabularEnergyAngle(
 }
 
 AngleEnergyPacket TabularEnergyAngle::sample_angle_energy(
-    double E_in, std::function<double()> rng) const {
+    double E_in, const std::function<double()>& rng) const {
   // Determine the index of the bounding tabulated incoming energies
   std::size_t l;
   double f;  // Interpolation factor

--- a/src/tabular_energy_angle.cpp
+++ b/src/tabular_energy_angle.cpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/src/tabulated_1d.cpp
+++ b/src/tabulated_1d.cpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/src/uncorrelated.cpp
+++ b/src/uncorrelated.cpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/src/uncorrelated.cpp
+++ b/src/uncorrelated.cpp
@@ -35,7 +35,7 @@ Uncorrelated::Uncorrelated(const AngleDistribution& angle,
 }
 
 AngleEnergyPacket Uncorrelated::sample_angle_energy(
-    double E_in, std::function<double()> rng) const {
+    double E_in, const std::function<double()>& rng) const {
   double mu = angle_.sample_angle(E_in, rng);
   double E_out = energy_->sample_energy(E_in, rng);
   return {mu, E_out};

--- a/src/urr_ptables.cpp
+++ b/src/urr_ptables.cpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/src/vector.hpp
+++ b/src/vector.hpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -24,8 +24,8 @@
 
 namespace pndl {
 const unsigned int VERSION_MAJOR = 0;
-const unsigned int VERSION_MINOR = 2;
-const unsigned int VERSION_PATCH = 1;
-const bool VERSION_DEVELOPMENT = true;
-const char* VERSION_STRING = "0.2.1-dev";
+const unsigned int VERSION_MINOR = 3;
+const unsigned int VERSION_PATCH = 0;
+const bool VERSION_DEVELOPMENT = false;
+const char* VERSION_STRING = "0.3.0";
 }  // namespace pndl

--- a/src/watt.cpp
+++ b/src/watt.cpp
@@ -101,7 +101,8 @@ Watt::Watt(std::shared_ptr<Tabulated1D> a, std::shared_ptr<Tabulated1D> b,
            double restriction_energy)
     : a_(a), b_(b), restriction_energy_(restriction_energy) {}
 
-double Watt::sample_energy(double E_in, const std::function<double()>& rng) const {
+double Watt::sample_energy(double E_in,
+                           const std::function<double()>& rng) const {
   double a = (*a_)(E_in);
   double b = (*b_)(E_in);
   double w = 0.;

--- a/src/watt.cpp
+++ b/src/watt.cpp
@@ -101,7 +101,7 @@ Watt::Watt(std::shared_ptr<Tabulated1D> a, std::shared_ptr<Tabulated1D> b,
            double restriction_energy)
     : a_(a), b_(b), restriction_energy_(restriction_energy) {}
 
-double Watt::sample_energy(double E_in, std::function<double()> rng) const {
+double Watt::sample_energy(double E_in, const std::function<double()>& rng) const {
   double a = (*a_)(E_in);
   double b = (*b_)(E_in);
   double w = 0.;

--- a/src/watt.cpp
+++ b/src/watt.cpp
@@ -1,6 +1,6 @@
 /*
  * Papillon Nuclear Data Library
- * Copyright 2021, Hunter Belanger
+ * Copyright 2021-2022, Hunter Belanger
  *
  * hunter.belanger@gmail.com
  *


### PR DESCRIPTION
Should be final PR before v0.3.0. Other than changing copyright headers and version numbers, all instances of `std::function<double()>` were changed to `const std::function<double()>&`, to ensure we don't waste resources copying function pointers when performing samplings.