### PR TITLE
Fix conversions warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,11 +100,11 @@ target_compile_features(PapillonNDL PUBLIC cxx_std_20)
 if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC") # Comile options for Windows
   target_compile_options(PapillonNDL PRIVATE /W4)
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU") # Compile options for GCC
-  target_compile_options(PapillonNDL PRIVATE -W -Wall -Wextra -Wpedantic)
+  target_compile_options(PapillonNDL PRIVATE -W -Wall -Wextra -Wconversion -Wpedantic)
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang") # Compile options for Clang
-  target_compile_options(PapillonNDL PRIVATE -W -Wall -Wextra -Wpedantic)
+  target_compile_options(PapillonNDL PRIVATE -W -Wall -Wextra -Wconversion -Wpedantic)
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Intel") # Compile options for Intel
-  target_compile_options(PapillonNDL PRIVATE -W -Wall -Wextra -Wpedantic)
+  target_compile_options(PapillonNDL PRIVATE -W -Wall -Wextra -Wconversion -Wpedantic)
 endif()
 
 # Must make the static PapillonNDL position independent on linux so that

--- a/include/PapillonNDL/cross_section.hpp
+++ b/include/PapillonNDL/cross_section.hpp
@@ -113,7 +113,7 @@ class CrossSection {
       return values_->back();
 
     const auto& egrid = energy_grid_->grid();
-    const auto erange_begin = egrid.begin() + index_;
+    const auto erange_begin = egrid.begin() + static_cast<std::vector<double>::difference_type>(index_);
     const auto erange_end = egrid.end();
 
     auto E_it = std::lower_bound(erange_begin, erange_end, E);
@@ -121,7 +121,7 @@ class CrossSection {
       return *(values_->begin() + std::distance(erange_begin, E_it));
     }
 
-    std::size_t i = std::distance(erange_begin, E_it) - 1;
+    std::size_t i = static_cast<std::size_t>(std::distance(erange_begin, E_it) - 1);
     double E_low = egrid[index_ + i];
     double E_hi = egrid[index_ + i + 1];
     double sig_low = (*values_)[i];

--- a/include/PapillonNDL/cross_section.hpp
+++ b/include/PapillonNDL/cross_section.hpp
@@ -113,7 +113,9 @@ class CrossSection {
       return values_->back();
 
     const auto& egrid = energy_grid_->grid();
-    const auto erange_begin = egrid.begin() + static_cast<std::vector<double>::difference_type>(index_);
+    const auto erange_begin =
+        egrid.begin() +
+        static_cast<std::vector<double>::difference_type>(index_);
     const auto erange_end = egrid.end();
 
     auto E_it = std::lower_bound(erange_begin, erange_end, E);
@@ -121,7 +123,8 @@ class CrossSection {
       return *(values_->begin() + std::distance(erange_begin, E_it));
     }
 
-    std::size_t i = static_cast<std::size_t>(std::distance(erange_begin, E_it) - 1);
+    std::size_t i =
+        static_cast<std::size_t>(std::distance(erange_begin, E_it) - 1);
     double E_low = egrid[index_ + i];
     double E_hi = egrid[index_ + i + 1];
     double sig_low = (*values_)[i];

--- a/include/PapillonNDL/energy_angle_table.hpp
+++ b/include/PapillonNDL/energy_angle_table.hpp
@@ -77,7 +77,8 @@ class EnergyAngleTable {
     double E_out, mu;
     double xi = rng();
     auto cdf_it = std::lower_bound(cdf_.begin(), cdf_.end(), xi);
-    std::size_t l = static_cast<std::size_t>(std::distance(cdf_.begin(), cdf_it) - 1);
+    std::size_t l =
+        static_cast<std::size_t>(std::distance(cdf_.begin(), cdf_it) - 1);
 
     // Must account for case where pdf_[l] = pdf_[l+1], which means  that
     // the slope is zero, and m=0. This results in nan for the linear alg.
@@ -135,7 +136,8 @@ class EnergyAngleTable {
     } else if (E_it == energy_.begin() && E_out < energy_.front()) {
       return 0.;
     }
-    std::size_t l = static_cast<std::size_t>(std::distance(energy_.begin(), E_it));
+    std::size_t l =
+        static_cast<std::size_t>(std::distance(energy_.begin(), E_it));
     if (E_out != *E_it) l--;
 
     if (interp_ == Interpolation::Histogram) {

--- a/include/PapillonNDL/energy_angle_table.hpp
+++ b/include/PapillonNDL/energy_angle_table.hpp
@@ -77,7 +77,7 @@ class EnergyAngleTable {
     double E_out, mu;
     double xi = rng();
     auto cdf_it = std::lower_bound(cdf_.begin(), cdf_.end(), xi);
-    std::size_t l = std::distance(cdf_.begin(), cdf_it) - 1;
+    std::size_t l = static_cast<std::size_t>(std::distance(cdf_.begin(), cdf_it) - 1);
 
     // Must account for case where pdf_[l] = pdf_[l+1], which means  that
     // the slope is zero, and m=0. This results in nan for the linear alg.
@@ -135,7 +135,7 @@ class EnergyAngleTable {
     } else if (E_it == energy_.begin() && E_out < energy_.front()) {
       return 0.;
     }
-    std::size_t l = std::distance(energy_.begin(), E_it);
+    std::size_t l = static_cast<std::size_t>(std::distance(energy_.begin(), E_it));
     if (E_out != *E_it) l--;
 
     if (interp_ == Interpolation::Histogram) {

--- a/include/PapillonNDL/energy_grid.hpp
+++ b/include/PapillonNDL/energy_grid.hpp
@@ -121,9 +121,7 @@ class EnergyGrid : public std::enable_shared_from_this<EnergyGrid> {
     uint32_t low_indx = bin_pointers_[bin];
     uint32_t hi_indx = bin_pointers_[bin + 1] + 1;
 
-    std::size_t ind = std::lower_bound(energy_values_.begin() + low_indx,
-                                       energy_values_.begin() + hi_indx, E) -
-                      energy_values_.begin() - 1;
+    std::size_t ind = static_cast<std::size_t>(std::lower_bound(energy_values_.begin() + low_indx, energy_values_.begin() + hi_indx, E) - energy_values_.begin() - 1);
 
     return ind;
   }

--- a/include/PapillonNDL/energy_grid.hpp
+++ b/include/PapillonNDL/energy_grid.hpp
@@ -121,7 +121,10 @@ class EnergyGrid : public std::enable_shared_from_this<EnergyGrid> {
     uint32_t low_indx = bin_pointers_[bin];
     uint32_t hi_indx = bin_pointers_[bin + 1] + 1;
 
-    std::size_t ind = static_cast<std::size_t>(std::lower_bound(energy_values_.begin() + low_indx, energy_values_.begin() + hi_indx, E) - energy_values_.begin() - 1);
+    std::size_t ind = static_cast<std::size_t>(
+        std::lower_bound(energy_values_.begin() + low_indx,
+                         energy_values_.begin() + hi_indx, E) -
+        energy_values_.begin() - 1);
 
     return ind;
   }

--- a/include/PapillonNDL/isotope.hpp
+++ b/include/PapillonNDL/isotope.hpp
@@ -158,7 +158,7 @@ class Isotope {
     const std::regex atomic_mass_regex("([0-9]{1,3})");
     std::regex_search(symbol, match, atomic_mass_regex);
     std::string atomic_mass_str(match[0].first, match[0].second);
-    A_ = std::stoul(atomic_mass_str);
+    A_ = static_cast<uint32_t>(std::stoul(atomic_mass_str));
 
     if (A_ < element_.Z()) {
       std::string mssg = "Cannot create isotope " + element_.name() + "-" +

--- a/include/PapillonNDL/kalbach_table.hpp
+++ b/include/PapillonNDL/kalbach_table.hpp
@@ -63,7 +63,8 @@ class KalbachTable {
 
   double sample_energy(double xi) const {
     auto cdf_it = std::lower_bound(cdf_.begin(), cdf_.end(), xi);
-    std::size_t l = static_cast<std::size_t>(std::distance(cdf_.begin(), cdf_it));
+    std::size_t l =
+        static_cast<std::size_t>(std::distance(cdf_.begin(), cdf_it));
     if (xi == *cdf_it) return energy_[l];
     l--;
 
@@ -97,7 +98,8 @@ class KalbachTable {
       return R_.back();
     else {
       auto E_it = std::lower_bound(energy_.begin(), energy_.end(), E);
-      std::size_t l = static_cast<std::size_t>(std::distance(energy_.begin(), E_it) - 1);
+      std::size_t l =
+          static_cast<std::size_t>(std::distance(energy_.begin(), E_it) - 1);
 
       if (interp_ == Interpolation::Histogram) {
         return Histogram::interpolate(E, energy_[l], R_[l], energy_[l + 1],
@@ -120,7 +122,8 @@ class KalbachTable {
       return A_.back();
     else {
       auto E_it = std::lower_bound(energy_.begin(), energy_.end(), E);
-      std::size_t l = static_cast<std::size_t>(std::distance(energy_.begin(), E_it) - 1);
+      std::size_t l =
+          static_cast<std::size_t>(std::distance(energy_.begin(), E_it) - 1);
 
       if (interp_ == Interpolation::Histogram) {
         return Histogram::interpolate(E, energy_[l], A_[l], energy_[l + 1],
@@ -176,7 +179,8 @@ class KalbachTable {
     } else if (E_it == energy_.begin() && E_out < energy_.front()) {
       return 0.;
     }
-    std::size_t l = static_cast<std::size_t>(std::distance(energy_.begin(), E_it));
+    std::size_t l =
+        static_cast<std::size_t>(std::distance(energy_.begin(), E_it));
     if (E_out != *E_it) l--;
 
     if (interp_ == Interpolation::Histogram) {

--- a/include/PapillonNDL/kalbach_table.hpp
+++ b/include/PapillonNDL/kalbach_table.hpp
@@ -63,7 +63,7 @@ class KalbachTable {
 
   double sample_energy(double xi) const {
     auto cdf_it = std::lower_bound(cdf_.begin(), cdf_.end(), xi);
-    std::size_t l = std::distance(cdf_.begin(), cdf_it);
+    std::size_t l = static_cast<std::size_t>(std::distance(cdf_.begin(), cdf_it));
     if (xi == *cdf_it) return energy_[l];
     l--;
 
@@ -97,7 +97,7 @@ class KalbachTable {
       return R_.back();
     else {
       auto E_it = std::lower_bound(energy_.begin(), energy_.end(), E);
-      std::size_t l = std::distance(energy_.begin(), E_it) - 1;
+      std::size_t l = static_cast<std::size_t>(std::distance(energy_.begin(), E_it) - 1);
 
       if (interp_ == Interpolation::Histogram) {
         return Histogram::interpolate(E, energy_[l], R_[l], energy_[l + 1],
@@ -120,7 +120,7 @@ class KalbachTable {
       return A_.back();
     else {
       auto E_it = std::lower_bound(energy_.begin(), energy_.end(), E);
-      std::size_t l = std::distance(energy_.begin(), E_it) - 1;
+      std::size_t l = static_cast<std::size_t>(std::distance(energy_.begin(), E_it) - 1);
 
       if (interp_ == Interpolation::Histogram) {
         return Histogram::interpolate(E, energy_[l], A_[l], energy_[l + 1],
@@ -176,7 +176,7 @@ class KalbachTable {
     } else if (E_it == energy_.begin() && E_out < energy_.front()) {
       return 0.;
     }
-    std::size_t l = std::distance(energy_.begin(), E_it);
+    std::size_t l = static_cast<std::size_t>(std::distance(energy_.begin(), E_it));
     if (E_out != *E_it) l--;
 
     if (interp_ == Interpolation::Histogram) {

--- a/include/PapillonNDL/pctable.hpp
+++ b/include/PapillonNDL/pctable.hpp
@@ -65,7 +65,8 @@ class PCTable {
    */
   double sample_value(double xi) const {
     auto cdf_it = std::lower_bound(cdf_.begin(), cdf_.end(), xi);
-    std::size_t l = static_cast<std::size_t>(std::distance(cdf_.begin(), cdf_it));
+    std::size_t l =
+        static_cast<std::size_t>(std::distance(cdf_.begin(), cdf_it));
     if (xi == *cdf_it) return values_[l];
 
     l--;
@@ -87,7 +88,8 @@ class PCTable {
     if (value < min_value() || value > max_value()) return 0.;
 
     auto val_it = std::lower_bound(values_.begin(), values_.end(), value);
-    std::size_t l = static_cast<std::size_t>(std::distance(values_.begin(), val_it));
+    std::size_t l =
+        static_cast<std::size_t>(std::distance(values_.begin(), val_it));
     if (value == *val_it) return pdf_[l];
 
     l--;

--- a/include/PapillonNDL/pctable.hpp
+++ b/include/PapillonNDL/pctable.hpp
@@ -65,7 +65,7 @@ class PCTable {
    */
   double sample_value(double xi) const {
     auto cdf_it = std::lower_bound(cdf_.begin(), cdf_.end(), xi);
-    std::size_t l = std::distance(cdf_.begin(), cdf_it);
+    std::size_t l = static_cast<std::size_t>(std::distance(cdf_.begin(), cdf_it));
     if (xi == *cdf_it) return values_[l];
 
     l--;
@@ -87,7 +87,7 @@ class PCTable {
     if (value < min_value() || value > max_value()) return 0.;
 
     auto val_it = std::lower_bound(values_.begin(), values_.end(), value);
-    std::size_t l = std::distance(values_.begin(), val_it);
+    std::size_t l = static_cast<std::size_t>(std::distance(values_.begin(), val_it));
     if (value == *val_it) return pdf_[l];
 
     l--;

--- a/include/PapillonNDL/st_coherent_elastic.hpp
+++ b/include/PapillonNDL/st_coherent_elastic.hpp
@@ -55,7 +55,8 @@ class STCoherentElastic : public STTSLReaction {
     if (E > bragg_edges_.front() && E < bragg_edges_.back()) {
       // Get index for lower bragg edge
       auto Eit = std::lower_bound(bragg_edges_.begin(), bragg_edges_.end(), E);
-      std::size_t l = static_cast<std::size_t>(std::distance(bragg_edges_.begin(), Eit) - 1);
+      std::size_t l = static_cast<std::size_t>(
+          std::distance(bragg_edges_.begin(), Eit) - 1);
       return structure_factor_sum_[l] / E;
     } else if (E < bragg_edges_.front()) {
       return 0.;
@@ -77,12 +78,16 @@ class STCoherentElastic : public STTSLReaction {
       // Get index for lower bragg edge
       auto Eit =
           std::lower_bound(bragg_edges_.begin(), bragg_edges_.end(), E_in);
-      std::size_t l = static_cast<std::size_t>(std::distance(bragg_edges_.begin(), Eit) - 1);
+      std::size_t l = static_cast<std::size_t>(
+          std::distance(bragg_edges_.begin(), Eit) - 1);
 
       // Sample which Bragg edge off of which we will scatter.
       double Prob = rng() * structure_factor_sum_[l];
-      auto Sit = std::lower_bound(structure_factor_sum_.begin(), structure_factor_sum_.begin() + static_cast<std::ptrdiff_t>(l), Prob);
-      std::size_t Si = static_cast<std::size_t>(std::distance(structure_factor_sum_.begin(), Sit));
+      auto Sit = std::lower_bound(
+          structure_factor_sum_.begin(),
+          structure_factor_sum_.begin() + static_cast<std::ptrdiff_t>(l), Prob);
+      std::size_t Si = static_cast<std::size_t>(
+          std::distance(structure_factor_sum_.begin(), Sit));
       double E_bragg = bragg_edges_[Si];
 
       // Calculate the cosine of the scattering angle.

--- a/include/PapillonNDL/st_coherent_elastic.hpp
+++ b/include/PapillonNDL/st_coherent_elastic.hpp
@@ -55,7 +55,7 @@ class STCoherentElastic : public STTSLReaction {
     if (E > bragg_edges_.front() && E < bragg_edges_.back()) {
       // Get index for lower bragg edge
       auto Eit = std::lower_bound(bragg_edges_.begin(), bragg_edges_.end(), E);
-      size_t l = std::distance(bragg_edges_.begin(), Eit) - 1;
+      std::size_t l = static_cast<std::size_t>(std::distance(bragg_edges_.begin(), Eit) - 1);
       return structure_factor_sum_[l] / E;
     } else if (E < bragg_edges_.front()) {
       return 0.;
@@ -77,13 +77,12 @@ class STCoherentElastic : public STTSLReaction {
       // Get index for lower bragg edge
       auto Eit =
           std::lower_bound(bragg_edges_.begin(), bragg_edges_.end(), E_in);
-      size_t l = std::distance(bragg_edges_.begin(), Eit) - 1;
+      std::size_t l = static_cast<std::size_t>(std::distance(bragg_edges_.begin(), Eit) - 1);
 
       // Sample which Bragg edge off of which we will scatter.
       double Prob = rng() * structure_factor_sum_[l];
-      auto Sit = std::lower_bound(structure_factor_sum_.begin(),
-                                  structure_factor_sum_.begin() + l, Prob);
-      std::size_t Si = std::distance(structure_factor_sum_.begin(), Sit);
+      auto Sit = std::lower_bound(structure_factor_sum_.begin(), structure_factor_sum_.begin() + static_cast<std::ptrdiff_t>(l), Prob);
+      std::size_t Si = static_cast<std::size_t>(std::distance(structure_factor_sum_.begin(), Sit));
       double E_bragg = bragg_edges_[Si];
 
       // Calculate the cosine of the scattering angle.

--- a/include/PapillonNDL/st_incoherent_elastic_ace.hpp
+++ b/include/PapillonNDL/st_incoherent_elastic_ace.hpp
@@ -71,7 +71,8 @@ class STIncoherentElasticACE : public STTSLReaction {
       i = incoming_energy_.size() - 2;
       f = 1.;
     } else {
-      i = static_cast<std::size_t>(std::distance(incoming_energy_.begin(), Eit) - 1);
+      i = static_cast<std::size_t>(
+          std::distance(incoming_energy_.begin(), Eit) - 1);
       f = (E_in - incoming_energy_[i]) /
           (incoming_energy_[i + 1] - incoming_energy_[i]);
     }

--- a/include/PapillonNDL/st_incoherent_elastic_ace.hpp
+++ b/include/PapillonNDL/st_incoherent_elastic_ace.hpp
@@ -71,7 +71,7 @@ class STIncoherentElasticACE : public STTSLReaction {
       i = incoming_energy_.size() - 2;
       f = 1.;
     } else {
-      i = std::distance(incoming_energy_.begin(), Eit) - 1;
+      i = static_cast<std::size_t>(std::distance(incoming_energy_.begin(), Eit) - 1);
       f = (E_in - incoming_energy_[i]) /
           (incoming_energy_[i + 1] - incoming_energy_[i]);
     }

--- a/include/PapillonNDL/st_neutron.hpp
+++ b/include/PapillonNDL/st_neutron.hpp
@@ -151,7 +151,7 @@ class STNeutron {
     if (mt == 18 || mt == 19 || mt == 20 || mt == 21 || mt == 38) {
       return fission_->reaction(mt);
     } else {
-      return reactions_[reaction_indices_[mt]];
+      return reactions_[static_cast<std::size_t>(reaction_indices_[mt])];
     }
   }
 

--- a/include/PapillonNDL/tabulated_1d.hpp
+++ b/include/PapillonNDL/tabulated_1d.hpp
@@ -183,7 +183,7 @@ class Tabulated1D : public Function1D {
       const auto hi_it = std::lower_bound(x_.begin(), x_.end(), x);
       const auto low_it = hi_it - 1;
 
-      std::size_t i = low_it - x_.begin();
+      std::size_t i = static_cast<std::size_t>(low_it - x_.begin());
 
       double x1 = *low_it;
       double x2 = *hi_it;
@@ -224,7 +224,7 @@ class Tabulated1D : public Function1D {
         auto hi_it = low_it;
         hi_it++;
 
-        std::size_t i = low_it - x_.begin();
+        std::size_t i = static_cast<std::size_t>(low_it - x_.begin());
 
         double x1 = *low_it;
         double x2 = *hi_it;

--- a/include/PapillonNDL/urr_ptables.hpp
+++ b/include/PapillonNDL/urr_ptables.hpp
@@ -115,7 +115,7 @@ class URRPTables {
     if (Eit == energy_->begin() || Eit == energy_->end()) {
       return std::nullopt;
     } else {
-      iE = std::distance(energy_->begin(), Eit) - 1;
+      iE = static_cast<std::size_t>(std::distance(energy_->begin(), Eit) - 1);
 
       if (interp_ == Interpolation::LinLin) {
         f = (E - (*energy_)[iE]) / ((*energy_)[iE + 1] - (*energy_)[iE]);
@@ -151,7 +151,7 @@ class URRPTables {
       xsout.fission = xsb_low.fission + f * (xsb_hi.fission - xsb_low.fission);
       xsout.heating = xsb_low.heating + f * (xsb_hi.heating - xsb_low.heating);
     } else {
-      if (xsb_low.elastic > 0. && xsb_hi.elastic) {
+      if (xsb_low.elastic > 0. && xsb_hi.elastic > 0.) {
         xsout.elastic =
             std::exp(std::log(xsb_low.elastic) +
                      f * std::log(xsb_hi.elastic / xsb_low.elastic));
@@ -159,7 +159,7 @@ class URRPTables {
         xsout.elastic = 0.;
       }
 
-      if (xsb_low.capture > 0. && xsb_hi.capture) {
+      if (xsb_low.capture > 0. && xsb_hi.capture > 0.) {
         xsout.capture =
             std::exp(std::log(xsb_low.capture) +
                      f * std::log(xsb_hi.capture / xsb_low.capture));
@@ -167,7 +167,7 @@ class URRPTables {
         xsout.capture = 0.;
       }
 
-      if (xsb_low.fission > 0. && xsb_hi.fission) {
+      if (xsb_low.fission > 0. && xsb_hi.fission > 0.) {
         xsout.fission =
             std::exp(std::log(xsb_low.fission) +
                      f * std::log(xsb_hi.fission / xsb_low.fission));
@@ -175,7 +175,7 @@ class URRPTables {
         xsout.fission = 0.;
       }
 
-      if (xsb_low.heating > 0. && xsb_hi.heating) {
+      if (xsb_low.heating > 0. && xsb_hi.heating > 0.) {
         xsout.heating =
             std::exp(std::log(xsb_low.heating) +
                      f * std::log(xsb_hi.heating / xsb_low.heating));

--- a/src/ace.cpp
+++ b/src/ace.cpp
@@ -326,19 +326,27 @@ void ACE::save_binary(std::string& fname) {
 
 std::vector<std::pair<int32_t, double>> ACE::izaw(std::size_t i,
                                                   std::size_t len) const {
-  return {izaw_.begin() + static_cast<std::ptrdiff_t>(i), izaw_.begin() + static_cast<std::ptrdiff_t>(i) + static_cast<std::ptrdiff_t>(len)};
+  return {izaw_.begin() + static_cast<std::ptrdiff_t>(i),
+          izaw_.begin() + static_cast<std::ptrdiff_t>(i) +
+              static_cast<std::ptrdiff_t>(len)};
 }
 
 std::vector<int32_t> ACE::nxs(std::size_t i, std::size_t len) const {
-  return {nxs_.begin() + static_cast<std::ptrdiff_t>(i), nxs_.begin() + static_cast<std::ptrdiff_t>(i) + static_cast<std::ptrdiff_t>(len)};
+  return {nxs_.begin() + static_cast<std::ptrdiff_t>(i),
+          nxs_.begin() + static_cast<std::ptrdiff_t>(i) +
+              static_cast<std::ptrdiff_t>(len)};
 }
 
 std::vector<int32_t> ACE::jxs(std::size_t i, std::size_t len) const {
-  return {jxs_.begin() + static_cast<std::ptrdiff_t>(i), jxs_.begin() + static_cast<std::ptrdiff_t>(i) + static_cast<std::ptrdiff_t>(len)};
+  return {jxs_.begin() + static_cast<std::ptrdiff_t>(i),
+          jxs_.begin() + static_cast<std::ptrdiff_t>(i) +
+              static_cast<std::ptrdiff_t>(len)};
 }
 
 std::vector<double> ACE::xss(std::size_t i, std::size_t len) const {
-  return {xss_.begin() + static_cast<std::ptrdiff_t>(i), xss_.begin() + static_cast<std::ptrdiff_t>(i) + static_cast<std::ptrdiff_t>(len)};
+  return {xss_.begin() + static_cast<std::ptrdiff_t>(i),
+          xss_.begin() + static_cast<std::ptrdiff_t>(i) +
+              static_cast<std::ptrdiff_t>(len)};
 }
 
 const double* ACE::xss_data() const { return xss_.data(); }

--- a/src/ace.cpp
+++ b/src/ace.cpp
@@ -143,7 +143,7 @@ void ACE::read_ascii(std::ifstream& file) {
   }
 
   // Parse IZAW
-  for (int i = 0; i < 16; i++) {
+  for (std::size_t i = 0; i < 16; i++) {
     int32_t i_zaid;
     double i_awr;
     file >> i_zaid;
@@ -152,20 +152,20 @@ void ACE::read_ascii(std::ifstream& file) {
   }
 
   // Parse NXS
-  for (int i = 0; i < 16; i++) {
+  for (std::size_t i = 0; i < 16; i++) {
     file >> nxs_[i];
   }
 
   // Parse JXS
-  for (int i = 0; i < 32; i++) {
+  for (std::size_t i = 0; i < 32; i++) {
     file >> jxs_[i];
   }
 
   // Parse XSS
-  xss_.resize(nxs_[0]);
+  xss_.resize(static_cast<std::size_t>(nxs_[0]));
   int i = 0;
   while (!file.eof() && i < nxs_[0]) {
-    file >> xss_[i];
+    file >> xss_[static_cast<std::size_t>(i)];
     i++;
   }
 
@@ -210,7 +210,7 @@ void ACE::read_binary(std::ifstream& file) {
   file.read(mat_.data(), 10);
 
   // Parse IZAW
-  for (int i = 0; i < 16; i++) {
+  for (std::size_t i = 0; i < 16; i++) {
     int32_t i_zaid;
     double i_awr;
 
@@ -220,12 +220,12 @@ void ACE::read_binary(std::ifstream& file) {
   }
 
   // Parse NXS
-  for (int i = 0; i < 16; i++) {
+  for (std::size_t i = 0; i < 16; i++) {
     file.read(reinterpret_cast<char*>(&nxs_[i]), sizeof(int32_t));
   }
 
   // Parse JXS
-  for (int i = 0; i < 32; i++) {
+  for (std::size_t i = 0; i < 32; i++) {
     file.read(reinterpret_cast<char*>(&jxs_[i]), sizeof(int32_t));
   }
 
@@ -233,7 +233,7 @@ void ACE::read_binary(std::ifstream& file) {
   file.ignore(4);
 
   // Parse XSS
-  xss_.resize(nxs_[0]);
+  xss_.resize(static_cast<std::size_t>(nxs_[0]));
   uint32_t rlen;
   std::size_t i = 0;
   while (!file.eof() && i < xss_.size()) {
@@ -326,19 +326,19 @@ void ACE::save_binary(std::string& fname) {
 
 std::vector<std::pair<int32_t, double>> ACE::izaw(std::size_t i,
                                                   std::size_t len) const {
-  return {izaw_.begin() + i, izaw_.begin() + i + len};
+  return {izaw_.begin() + static_cast<std::ptrdiff_t>(i), izaw_.begin() + static_cast<std::ptrdiff_t>(i) + static_cast<std::ptrdiff_t>(len)};
 }
 
 std::vector<int32_t> ACE::nxs(std::size_t i, std::size_t len) const {
-  return {nxs_.begin() + i, nxs_.begin() + i + len};
+  return {nxs_.begin() + static_cast<std::ptrdiff_t>(i), nxs_.begin() + static_cast<std::ptrdiff_t>(i) + static_cast<std::ptrdiff_t>(len)};
 }
 
 std::vector<int32_t> ACE::jxs(std::size_t i, std::size_t len) const {
-  return {jxs_.begin() + i, jxs_.begin() + i + len};
+  return {jxs_.begin() + static_cast<std::ptrdiff_t>(i), jxs_.begin() + static_cast<std::ptrdiff_t>(i) + static_cast<std::ptrdiff_t>(len)};
 }
 
 std::vector<double> ACE::xss(std::size_t i, std::size_t len) const {
-  return {xss_.begin() + i, xss_.begin() + i + len};
+  return {xss_.begin() + static_cast<std::ptrdiff_t>(i), xss_.begin() + static_cast<std::ptrdiff_t>(i) + static_cast<std::ptrdiff_t>(len)};
 }
 
 const double* ACE::xss_data() const { return xss_.data(); }

--- a/src/angle_distribution.cpp
+++ b/src/angle_distribution.cpp
@@ -53,7 +53,7 @@ AngleDistribution::AngleDistribution(const ACE& ace, int locb)
 
   if (locb > 0) {
     // Set index
-    std::size_t i = ace.AND() + locb - 1;
+    std::size_t i = static_cast<std::size_t>(ace.AND() + locb - 1);
 
     // Get number of energies
     uint32_t NE = ace.xss<uint32_t>(i);
@@ -70,7 +70,7 @@ AngleDistribution::AngleDistribution(const ACE& ace, int locb)
     // Get each table
     for (uint32_t j = 0; j < NE; j++) {
       int l = ace.xss<int>(i + 1 + NE + j);
-      uint32_t loc = ace.AND() + std::abs(l) - 1;
+      uint32_t loc = static_cast<uint32_t>(ace.AND() + std::abs(l) - 1);
 
       try {
         if (l > 0) {
@@ -123,7 +123,7 @@ double AngleDistribution::sample_angle(
   E_it--;
 
   // Get index of low energy
-  std::size_t l = std::distance(energy_grid_.begin(), E_it);
+  std::size_t l = static_cast<std::size_t>(std::distance(energy_grid_.begin(), E_it));
   double f = (E_in - energy_grid_[l]) / (energy_grid_[l + 1] - energy_grid_[l]);
 
   double mu = 0;
@@ -147,7 +147,7 @@ double AngleDistribution::pdf(double E_in, double mu) const {
   E_it--;
 
   // Get index of low energy
-  std::size_t l = std::distance(energy_grid_.begin(), E_it);
+  std::size_t l = static_cast<std::size_t>(std::distance(energy_grid_.begin(), E_it));
   double f = (E_in - energy_grid_[l]) / (energy_grid_[l + 1] - energy_grid_[l]);
 
   return (1. - f) * laws_[l]->pdf(mu) + f * laws_[l + 1]->pdf(mu);

--- a/src/angle_distribution.cpp
+++ b/src/angle_distribution.cpp
@@ -123,7 +123,8 @@ double AngleDistribution::sample_angle(
   E_it--;
 
   // Get index of low energy
-  std::size_t l = static_cast<std::size_t>(std::distance(energy_grid_.begin(), E_it));
+  std::size_t l =
+      static_cast<std::size_t>(std::distance(energy_grid_.begin(), E_it));
   double f = (E_in - energy_grid_[l]) / (energy_grid_[l + 1] - energy_grid_[l]);
 
   double mu = 0;
@@ -147,7 +148,8 @@ double AngleDistribution::pdf(double E_in, double mu) const {
   E_it--;
 
   // Get index of low energy
-  std::size_t l = static_cast<std::size_t>(std::distance(energy_grid_.begin(), E_it));
+  std::size_t l =
+      static_cast<std::size_t>(std::distance(energy_grid_.begin(), E_it));
   double f = (E_in - energy_grid_[l]) / (energy_grid_[l + 1] - energy_grid_[l]);
 
   return (1. - f) * laws_[l]->pdf(mu) + f * laws_[l + 1]->pdf(mu);

--- a/src/continuous_energy_discrete_cosines.cpp
+++ b/src/continuous_energy_discrete_cosines.cpp
@@ -235,7 +235,8 @@ ContinuousEnergyDiscreteCosines::sample_with_unit_based_interpolation(
     l = incoming_energy_.size() - 2;
     f = 1.;
   } else {
-    l = static_cast<std::size_t>(std::distance(incoming_energy_.begin(), in_E_it) - 1);
+    l = static_cast<std::size_t>(
+        std::distance(incoming_energy_.begin(), in_E_it) - 1);
     f = (E_in - incoming_energy_[l]) /
         (incoming_energy_[l + 1] - incoming_energy_[l]);
   }
@@ -317,7 +318,8 @@ ContinuousEnergyDiscreteCosines::sample_without_unit_based_interpolation(
     l = incoming_energy_.size() - 2;
     f = 1.;
   } else {
-    l = static_cast<std::size_t>(std::distance(incoming_energy_.begin(), in_E_it) - 1);
+    l = static_cast<std::size_t>(
+        std::distance(incoming_energy_.begin(), in_E_it) - 1);
     f = (E_in - incoming_energy_[l]) /
         (incoming_energy_[l + 1] - incoming_energy_[l]);
   }

--- a/src/continuous_energy_discrete_cosines.cpp
+++ b/src/continuous_energy_discrete_cosines.cpp
@@ -46,7 +46,7 @@ ContinuousEnergyDiscreteCosines::ContinuousEnergyDiscreteCosines(
   }
 
   // Read incident energy grid
-  int32_t S = ace.jxs(0) - 1;
+  std::size_t S = static_cast<std::size_t>(ace.jxs(0) - 1);
   uint32_t Ne = ace.xss<uint32_t>(S);  // Number of grid points
   incoming_energy_ = ace.xss(S + 1, Ne);
 
@@ -60,7 +60,7 @@ ContinuousEnergyDiscreteCosines::ContinuousEnergyDiscreteCosines(
   Nmu = static_cast<uint32_t>(ace.nxs(2)) - 1;
 
   // Get the starting index for the locators and sizes
-  uint32_t i = ace.jxs(2) - 1;
+  uint32_t i = static_cast<uint32_t>(ace.jxs(2) - 1);
   // Locators in xss for each incident energy
   std::vector<uint32_t> locs = ace.xss<uint32_t>(i, Ne);
   // Number of outgoing energies for each incident energy
@@ -235,7 +235,7 @@ ContinuousEnergyDiscreteCosines::sample_with_unit_based_interpolation(
     l = incoming_energy_.size() - 2;
     f = 1.;
   } else {
-    l = std::distance(incoming_energy_.begin(), in_E_it) - 1;
+    l = static_cast<std::size_t>(std::distance(incoming_energy_.begin(), in_E_it) - 1);
     f = (E_in - incoming_energy_[l]) /
         (incoming_energy_[l + 1] - incoming_energy_[l]);
   }
@@ -317,7 +317,7 @@ ContinuousEnergyDiscreteCosines::sample_without_unit_based_interpolation(
     l = incoming_energy_.size() - 2;
     f = 1.;
   } else {
-    l = std::distance(incoming_energy_.begin(), in_E_it) - 1;
+    l = static_cast<std::size_t>(std::distance(incoming_energy_.begin(), in_E_it) - 1);
     f = (E_in - incoming_energy_[l]) /
         (incoming_energy_[l + 1] - incoming_energy_[l]);
   }
@@ -383,7 +383,7 @@ double ContinuousEnergyDiscreteCosines::CEDCTable::sample_energy(
   } else if (cdf_it == cdf.end()) {
     l = energy.size() - 2;
   } else {
-    l = std::distance(cdf.begin(), cdf_it) - 1;
+    l = static_cast<std::size_t>(std::distance(cdf.begin(), cdf_it) - 1);
   }
 
   // Must account for case where pdf_[l] = pdf_[l+1], which means  that

--- a/src/cross_section.cpp
+++ b/src/cross_section.cpp
@@ -102,7 +102,8 @@ CrossSection::CrossSection(double xs, std::shared_ptr<EnergyGrid> E_grid)
 }
 
 std::vector<double> CrossSection::energy() const {
-  return {energy_grid_->grid().begin() + static_cast<std::ptrdiff_t>(index_), energy_grid_->grid().end()};
+  return {energy_grid_->grid().begin() + static_cast<std::ptrdiff_t>(index_),
+          energy_grid_->grid().end()};
 }
 
 }  // namespace pndl

--- a/src/cross_section.cpp
+++ b/src/cross_section.cpp
@@ -31,7 +31,7 @@ CrossSection::CrossSection(const ACE& ace, std::size_t i,
                            std::shared_ptr<EnergyGrid> E_grid, bool get_index,
                            bool is_heating)
     : energy_grid_(E_grid), values_(nullptr), index_(0), single_value_(false) {
-  uint32_t NE = ace.nxs(2);
+  uint32_t NE = static_cast<uint32_t>(ace.nxs(2));
   if (get_index) {
     index_ = ace.xss<uint32_t>(i) - 1;
     i++;
@@ -102,7 +102,7 @@ CrossSection::CrossSection(double xs, std::shared_ptr<EnergyGrid> E_grid)
 }
 
 std::vector<double> CrossSection::energy() const {
-  return {energy_grid_->grid().begin() + index_, energy_grid_->grid().end()};
+  return {energy_grid_->grid().begin() + static_cast<std::ptrdiff_t>(index_), energy_grid_->grid().end()};
 }
 
 }  // namespace pndl

--- a/src/delayed_family.cpp
+++ b/src/delayed_family.cpp
@@ -61,7 +61,8 @@ DelayedFamily::DelayedFamily(const ACE& ace, std::size_t i, std::size_t g)
   }
 
   // Get energy distribution location
-  uint32_t locc = ace.xss<uint32_t>(static_cast<std::size_t>(ace.DNEDL()) + g - 1);
+  uint32_t locc =
+      ace.xss<uint32_t>(static_cast<std::size_t>(ace.DNEDL()) + g - 1);
   std::size_t l = static_cast<std::size_t>(ace.DNED()) + locc - 1;
 
   // TODO currently ignore extra distribuitons, only read first one

--- a/src/delayed_family.cpp
+++ b/src/delayed_family.cpp
@@ -61,8 +61,8 @@ DelayedFamily::DelayedFamily(const ACE& ace, std::size_t i, std::size_t g)
   }
 
   // Get energy distribution location
-  uint32_t locc = ace.xss<uint32_t>(ace.DNEDL() + g - 1);
-  std::size_t l = ace.DNED() + locc - 1;
+  uint32_t locc = ace.xss<uint32_t>(static_cast<std::size_t>(ace.DNEDL()) + g - 1);
+  std::size_t l = static_cast<std::size_t>(ace.DNED()) + locc - 1;
 
   // TODO currently ignore extra distribuitons, only read first one
   // Write a warning for now
@@ -75,7 +75,7 @@ DelayedFamily::DelayedFamily(const ACE& ace, std::size_t i, std::size_t g)
 
   int law = ace.xss<int>(l + 1);
   uint32_t idat = ace.xss<uint32_t>(l + 2);
-  std::size_t j = ace.DNED() + idat - 1;
+  std::size_t j = static_cast<std::size_t>(ace.DNED()) + idat - 1;
 
   if (law == 1) {  // Equiprobable Energy Bins
     energy_ = std::make_shared<EquiprobableEnergyBins>(ace, j);

--- a/src/discrete_cosines_energies.cpp
+++ b/src/discrete_cosines_energies.cpp
@@ -47,7 +47,7 @@ DiscreteCosinesEnergies::DiscreteCosinesEnergies(const ACE& ace)
   }
 
   // Read incident energy grid
-  int32_t S = ace.jxs(0) - 1;
+  std::size_t S = static_cast<std::size_t>(ace.jxs(0) - 1);
   uint32_t Ne = ace.xss<uint32_t>(S);  // Number of grid points
   incoming_energy_ = ace.xss(S + 1, Ne);
 
@@ -70,7 +70,7 @@ DiscreteCosinesEnergies::DiscreteCosinesEnergies(const ACE& ace)
   Nmu = static_cast<uint32_t>(ace.nxs(2)) + 1;
 
   // Get the starting index for the distribution data
-  int32_t i = ace.jxs(2) - 1;
+  std::size_t i = static_cast<std::size_t>(ace.jxs(2) - 1);
 
   // Go through all incident energies
   for (std::size_t ie = 0; ie < Ne; ie++) {
@@ -92,8 +92,7 @@ DiscreteCosinesEnergies::DiscreteCosinesEnergies(const ACE& ace)
       // Check mu grid
       for (std::size_t j = 0; j < Nmu; j++) {
         if (mu[j] < -1. || mu[j] > 1.) {
-          std::string mssg = "Invalid cosine value found at index " +
-                             std::to_string(i + j) + ".";
+          std::string mssg = "Invalid cosine value found at index " + std::to_string(static_cast<std::size_t>(i) + j) + ".";
           throw PNDLException(mssg);
         }
       }
@@ -147,7 +146,7 @@ AngleEnergyPacket DiscreteCosinesEnergies::sample_angle_energy(
     return {outgoing_energies_.back()[j].cosines[k],
             outgoing_energies_.back()[j].energy};
   }
-  std::size_t i = std::distance(incoming_energy_.begin(), Eit) - 1;
+  std::size_t i = static_cast<std::size_t>(std::distance(incoming_energy_.begin(), Eit) - 1);
   double f = (E_in - incoming_energy_[i]) /
              (incoming_energy_[i + 1] - incoming_energy_[i]);
 

--- a/src/discrete_cosines_energies.cpp
+++ b/src/discrete_cosines_energies.cpp
@@ -92,7 +92,9 @@ DiscreteCosinesEnergies::DiscreteCosinesEnergies(const ACE& ace)
       // Check mu grid
       for (std::size_t j = 0; j < Nmu; j++) {
         if (mu[j] < -1. || mu[j] > 1.) {
-          std::string mssg = "Invalid cosine value found at index " + std::to_string(static_cast<std::size_t>(i) + j) + ".";
+          std::string mssg = "Invalid cosine value found at index " +
+                             std::to_string(static_cast<std::size_t>(i) + j) +
+                             ".";
           throw PNDLException(mssg);
         }
       }
@@ -146,7 +148,8 @@ AngleEnergyPacket DiscreteCosinesEnergies::sample_angle_energy(
     return {outgoing_energies_.back()[j].cosines[k],
             outgoing_energies_.back()[j].energy};
   }
-  std::size_t i = static_cast<std::size_t>(std::distance(incoming_energy_.begin(), Eit) - 1);
+  std::size_t i = static_cast<std::size_t>(
+      std::distance(incoming_energy_.begin(), Eit) - 1);
   double f = (E_in - incoming_energy_[i]) /
              (incoming_energy_[i + 1] - incoming_energy_[i]);
 

--- a/src/energy_angle_table.cpp
+++ b/src/energy_angle_table.cpp
@@ -90,7 +90,7 @@ EnergyAngleTable::EnergyAngleTable(const ACE& ace, std::size_t i,
   std::vector<int32_t> locs = ace.xss<int32_t>(i + 2 + NP + NP + NP, NP);
   for (std::size_t j = 0; j < locs.size(); j++) {
     int32_t loc = locs[j];
-    std::size_t l = JED + std::abs(loc) - 1;
+    std::size_t l = JED + static_cast<std::size_t>(std::abs(loc)) - 1;
     try {
       angles_.emplace_back(ace, l);
     } catch (PNDLException& error) {

--- a/src/energy_grid.cpp
+++ b/src/energy_grid.cpp
@@ -32,7 +32,7 @@ EnergyGrid::EnergyGrid(const ACE& ace, uint32_t NBINS)
       u_min(),
       du(),
       urr_start_energy_() {
-  energy_values_ = ace.xss(ace.ESZ(), ace.nxs(2));
+  energy_values_ = ace.xss(static_cast<std::size_t>(ace.ESZ()), static_cast<std::size_t>(ace.nxs(2)));
 
   // Check if there are URR tables.
   if (ace.jxs(22) != 0) {
@@ -95,10 +95,7 @@ void EnergyGrid::hash_energy_grid(uint32_t NBINS) {
   for (std::size_t b = 1; b < NBINS + 1; b++) {
     E *= std::exp(du);
 
-    i = std::distance(
-            energy_values_.begin(),
-            std::lower_bound(energy_values_.begin(), energy_values_.end(), E)) -
-        1;
+    i = static_cast<std::size_t>(std::distance(energy_values_.begin(), std::lower_bound(energy_values_.begin(), energy_values_.end(), E)) - 1);
 
     bin_pointers_.push_back(static_cast<uint32_t>(i));
   }

--- a/src/energy_grid.cpp
+++ b/src/energy_grid.cpp
@@ -32,7 +32,8 @@ EnergyGrid::EnergyGrid(const ACE& ace, uint32_t NBINS)
       u_min(),
       du(),
       urr_start_energy_() {
-  energy_values_ = ace.xss(static_cast<std::size_t>(ace.ESZ()), static_cast<std::size_t>(ace.nxs(2)));
+  energy_values_ = ace.xss(static_cast<std::size_t>(ace.ESZ()),
+                           static_cast<std::size_t>(ace.nxs(2)));
 
   // Check if there are URR tables.
   if (ace.jxs(22) != 0) {
@@ -95,7 +96,11 @@ void EnergyGrid::hash_energy_grid(uint32_t NBINS) {
   for (std::size_t b = 1; b < NBINS + 1; b++) {
     E *= std::exp(du);
 
-    i = static_cast<std::size_t>(std::distance(energy_values_.begin(), std::lower_bound(energy_values_.begin(), energy_values_.end(), E)) - 1);
+    i = static_cast<std::size_t>(
+        std::distance(
+            energy_values_.begin(),
+            std::lower_bound(energy_values_.begin(), energy_values_.end(), E)) -
+        1);
 
     bin_pointers_.push_back(static_cast<uint32_t>(i));
   }

--- a/src/equiprobable_angle_bins.cpp
+++ b/src/equiprobable_angle_bins.cpp
@@ -83,7 +83,7 @@ double EquiprobableAngleBins::sample_mu(
   std::size_t bin =
       static_cast<std::size_t>(std::floor(static_cast<double>(NBOUNDS) * xi));
   if (bin == NBOUNDS) bin--;
-  double C_b = bin * P_BIN;
+  double C_b = static_cast<double>(bin) * P_BIN;
   double mu_low = bounds_[bin];
   double mu = ((xi - C_b) / P_BIN) + mu_low;
 

--- a/src/equiprobable_energy_bins.cpp
+++ b/src/equiprobable_energy_bins.cpp
@@ -140,7 +140,7 @@ std::optional<double> EquiprobableEnergyBins::pdf(double E_in,
 
 double EquiprobableEnergyBins::sample_bins(
     double xi1, double xi2, const std::vector<double>& bounds) const {
-  std::size_t bin = static_cast<std::size_t>(std::floor(bounds.size() * xi1));
+  std::size_t bin = static_cast<std::size_t>(std::floor(static_cast<double>(bounds.size()) * xi1));
   return (bounds[bin + 1] - bounds[bin]) * xi2 + bounds[bin];
 }
 

--- a/src/equiprobable_energy_bins.cpp
+++ b/src/equiprobable_energy_bins.cpp
@@ -104,7 +104,8 @@ double EquiprobableEnergyBins::sample_energy(
     return sample_bins(rng(), rng(), bin_sets_.back());
   }
 
-  std::size_t l = static_cast<std::size_t>(std::distance(incoming_energy_.begin(), in_E_it));
+  std::size_t l = static_cast<std::size_t>(
+      std::distance(incoming_energy_.begin(), in_E_it));
   l--;
 
   double f = (E_in - incoming_energy_[l]) /
@@ -128,7 +129,8 @@ std::optional<double> EquiprobableEnergyBins::pdf(double E_in,
     return pdf_bins(E_out, bin_sets_.back());
   }
 
-  std::size_t l = static_cast<std::size_t>(std::distance(incoming_energy_.begin(), in_E_it));
+  std::size_t l = static_cast<std::size_t>(
+      std::distance(incoming_energy_.begin(), in_E_it));
   l--;
 
   double f = (E_in - incoming_energy_[l]) /
@@ -140,7 +142,8 @@ std::optional<double> EquiprobableEnergyBins::pdf(double E_in,
 
 double EquiprobableEnergyBins::sample_bins(
     double xi1, double xi2, const std::vector<double>& bounds) const {
-  std::size_t bin = static_cast<std::size_t>(std::floor(static_cast<double>(bounds.size()) * xi1));
+  std::size_t bin = static_cast<std::size_t>(
+      std::floor(static_cast<double>(bounds.size()) * xi1));
   return (bounds[bin + 1] - bounds[bin]) * xi2 + bounds[bin];
 }
 

--- a/src/equiprobable_energy_bins.cpp
+++ b/src/equiprobable_energy_bins.cpp
@@ -104,7 +104,7 @@ double EquiprobableEnergyBins::sample_energy(
     return sample_bins(rng(), rng(), bin_sets_.back());
   }
 
-  std::size_t l = std::distance(incoming_energy_.begin(), in_E_it);
+  std::size_t l = static_cast<std::size_t>(std::distance(incoming_energy_.begin(), in_E_it));
   l--;
 
   double f = (E_in - incoming_energy_[l]) /
@@ -128,7 +128,7 @@ std::optional<double> EquiprobableEnergyBins::pdf(double E_in,
     return pdf_bins(E_out, bin_sets_.back());
   }
 
-  std::size_t l = std::distance(incoming_energy_.begin(), in_E_it);
+  std::size_t l = static_cast<std::size_t>(std::distance(incoming_energy_.begin(), in_E_it));
   l--;
 
   double f = (E_in - incoming_energy_[l]) /

--- a/src/fission.cpp
+++ b/src/fission.cpp
@@ -61,20 +61,19 @@ Fission::Fission(const ACE& ace, std::shared_ptr<EnergyGrid> energy_grid)
 
       // If prompt and or total neutrons are given
       if (ace.jxs(1) > 0) {
-        if (ace.xss(ace.NU()) > 0.) {
+        if (ace.xss(static_cast<std::size_t>(ace.NU())) > 0.) {
           // Either prompt or total given, but not both
           if (ace.jxs(23) > 0) {
             // Prompt is provided, as delayed is present
-            prompt = read_nu(ace, ace.NU());
+            prompt = read_nu(ace, static_cast<std::size_t>(ace.NU()));
           } else {
             // No delayed, so this must be total
-            total = read_nu(ace, ace.NU());
+            total = read_nu(ace, static_cast<std::size_t>(ace.NU()));
           }
         } else {
           // Both prompt and total given
-          uint32_t KNU_prmpt = ace.NU() + 1;
-          uint32_t KNU_tot =
-              ace.NU() + std::abs(ace.xss<int32_t>(ace.NU())) + 1;
+          uint32_t KNU_prmpt = static_cast<uint32_t>(ace.NU() + 1);
+          uint32_t KNU_tot = static_cast<uint32_t>(ace.NU() + std::abs(ace.xss<int32_t>(static_cast<std::size_t>(ace.NU()))) + 1);
 
           total = read_nu(ace, KNU_tot);
           prompt = read_nu(ace, KNU_prmpt);
@@ -83,7 +82,7 @@ Fission::Fission(const ACE& ace, std::shared_ptr<EnergyGrid> energy_grid)
 
       // Read delayed nu if given
       if (ace.DNU() > 0) {
-        delayed = read_nu(ace, ace.DNU());
+        delayed = read_nu(ace, static_cast<std::size_t>(ace.DNU()));
       }
 
       // First we make nu_total_
@@ -123,9 +122,9 @@ Fission::Fission(const ACE& ace, std::shared_ptr<EnergyGrid> energy_grid)
     // Read all delayed family data
     try {
       if (ace.BDD() > 0) {
-        uint32_t NGRPS = ace.nxs(7);
+        uint32_t NGRPS = static_cast<uint32_t>(ace.nxs(7));
         std::size_t g = 1;
-        std::size_t i = ace.BDD();
+        std::size_t i = static_cast<std::size_t>(ace.BDD());
         while (g <= NGRPS) {
           delayed_families_.push_back(DelayedFamily(ace, i, g));
           uint32_t NR = ace.xss<uint32_t>(i + 1);
@@ -142,10 +141,10 @@ Fission::Fission(const ACE& ace, std::shared_ptr<EnergyGrid> energy_grid)
 
     // Read all fission reactions
     try {
-      uint32_t NMT = ace.nxs(3);
+      uint32_t NMT = static_cast<uint32_t>(ace.nxs(3));
       mt_list_.reserve(5);
       for (uint32_t indx = 0; indx < NMT; indx++) {
-        uint32_t MT = ace.xss<uint32_t>(ace.MTR() + indx);
+        uint32_t MT = ace.xss<uint32_t>(static_cast<std::size_t>(ace.MTR()) + indx);
         if (MT == 18) {
           mt18_ = std::make_shared<STReaction>(ace, indx, energy_grid);
           mt_list_.push_back(18);
@@ -209,10 +208,10 @@ Fission::Fission(const ACE& ace, std::shared_ptr<EnergyGrid> energy_grid,
   } else {
     // Read all fission reactions
     try {
-      uint32_t NMT = ace.nxs(3);
+      uint32_t NMT = static_cast<uint32_t>(ace.nxs(3));
       mt_list_.reserve(5);
       for (uint32_t indx = 0; indx < NMT; indx++) {
-        uint32_t MT = ace.xss<uint32_t>(ace.MTR() + indx);
+        uint32_t MT = ace.xss<uint32_t>(static_cast<std::size_t>(ace.MTR()) + indx);
         if (MT == 18) {
           mt18_ = std::make_shared<STReaction>(ace, indx, energy_grid,
                                                *fission.mt18_);

--- a/src/fission.cpp
+++ b/src/fission.cpp
@@ -73,7 +73,10 @@ Fission::Fission(const ACE& ace, std::shared_ptr<EnergyGrid> energy_grid)
         } else {
           // Both prompt and total given
           uint32_t KNU_prmpt = static_cast<uint32_t>(ace.NU() + 1);
-          uint32_t KNU_tot = static_cast<uint32_t>(ace.NU() + std::abs(ace.xss<int32_t>(static_cast<std::size_t>(ace.NU()))) + 1);
+          uint32_t KNU_tot = static_cast<uint32_t>(
+              ace.NU() +
+              std::abs(ace.xss<int32_t>(static_cast<std::size_t>(ace.NU()))) +
+              1);
 
           total = read_nu(ace, KNU_tot);
           prompt = read_nu(ace, KNU_prmpt);
@@ -144,7 +147,8 @@ Fission::Fission(const ACE& ace, std::shared_ptr<EnergyGrid> energy_grid)
       uint32_t NMT = static_cast<uint32_t>(ace.nxs(3));
       mt_list_.reserve(5);
       for (uint32_t indx = 0; indx < NMT; indx++) {
-        uint32_t MT = ace.xss<uint32_t>(static_cast<std::size_t>(ace.MTR()) + indx);
+        uint32_t MT =
+            ace.xss<uint32_t>(static_cast<std::size_t>(ace.MTR()) + indx);
         if (MT == 18) {
           mt18_ = std::make_shared<STReaction>(ace, indx, energy_grid);
           mt_list_.push_back(18);
@@ -211,7 +215,8 @@ Fission::Fission(const ACE& ace, std::shared_ptr<EnergyGrid> energy_grid,
       uint32_t NMT = static_cast<uint32_t>(ace.nxs(3));
       mt_list_.reserve(5);
       for (uint32_t indx = 0; indx < NMT; indx++) {
-        uint32_t MT = ace.xss<uint32_t>(static_cast<std::size_t>(ace.MTR()) + indx);
+        uint32_t MT =
+            ace.xss<uint32_t>(static_cast<std::size_t>(ace.MTR()) + indx);
         if (MT == 18) {
           mt18_ = std::make_shared<STReaction>(ace, indx, energy_grid,
                                                *fission.mt18_);

--- a/src/general_evaporation.cpp
+++ b/src/general_evaporation.cpp
@@ -86,8 +86,8 @@ double GeneralEvaporation::sample_energy(
     double E_in, const std::function<double()>& rng) const {
   double T = (*temperature_)(E_in);
   double xi1 = rng();
-  std::size_t bin =
-    static_cast<std::size_t>(std::floor(static_cast<double>(bin_bounds_.size()) * xi1));
+  std::size_t bin = static_cast<std::size_t>(
+      std::floor(static_cast<double>(bin_bounds_.size()) * xi1));
   double xi2 = rng();
   double Chi =
       (bin_bounds_[bin + 1] - bin_bounds_[bin]) * xi2 + bin_bounds_[bin];

--- a/src/general_evaporation.cpp
+++ b/src/general_evaporation.cpp
@@ -87,7 +87,7 @@ double GeneralEvaporation::sample_energy(
   double T = (*temperature_)(E_in);
   double xi1 = rng();
   std::size_t bin =
-      static_cast<std::size_t>(std::floor(bin_bounds_.size() * xi1));
+    static_cast<std::size_t>(std::floor(static_cast<double>(bin_bounds_.size()) * xi1));
   double xi2 = rng();
   double Chi =
       (bin_bounds_[bin + 1] - bin_bounds_[bin]) * xi2 + bin_bounds_[bin];

--- a/src/kalbach.cpp
+++ b/src/kalbach.cpp
@@ -48,7 +48,7 @@ Kalbach::Kalbach(const ACE& ace, std::size_t i)
 
   // Read outgoing energy tables
   for (uint32_t j = 0; j < NE; j++) {
-    uint32_t loc = ace.DLW() + ace.xss<uint32_t>(i + 2 + 2 * NR + NE + j) - 1;
+    uint32_t loc = static_cast<uint32_t>(ace.DLW()) + ace.xss<uint32_t>(i + 2 + 2 * NR + NE + j) - 1;
     try {
       tables_.emplace_back(ace, loc);
     } catch (PNDLException& error) {
@@ -92,7 +92,7 @@ AngleEnergyPacket Kalbach::sample_angle_energy(
     l = incoming_energy_.size() - 2;
     f = 1.;
   } else {
-    l = std::distance(incoming_energy_.begin(), in_E_it) - 1;
+    l = static_cast<std::size_t>(std::distance(incoming_energy_.begin(), in_E_it) - 1);
     f = (E_in - incoming_energy_[l]) /
         (incoming_energy_[l + 1] - incoming_energy_[l]);
   }
@@ -152,7 +152,7 @@ std::optional<double> Kalbach::angle_pdf(double E_in, double mu) const {
     l = incoming_energy_.size() - 2;
     f = 1.;
   } else {
-    l = std::distance(incoming_energy_.begin(), in_E_it) - 1;
+    l = static_cast<std::size_t>(std::distance(incoming_energy_.begin(), in_E_it) - 1);
     f = (E_in - incoming_energy_[l]) /
         (incoming_energy_[l + 1] - incoming_energy_[l]);
   }
@@ -181,7 +181,7 @@ std::optional<double> Kalbach::pdf(double E_in, double mu, double E_out) const {
     l = incoming_energy_.size() - 2;
     f = 1.;
   } else {
-    l = std::distance(incoming_energy_.begin(), in_E_it) - 1;
+    l = static_cast<std::size_t>(std::distance(incoming_energy_.begin(), in_E_it) - 1);
     f = (E_in - incoming_energy_[l]) /
         (incoming_energy_[l + 1] - incoming_energy_[l]);
   }

--- a/src/kalbach.cpp
+++ b/src/kalbach.cpp
@@ -48,7 +48,8 @@ Kalbach::Kalbach(const ACE& ace, std::size_t i)
 
   // Read outgoing energy tables
   for (uint32_t j = 0; j < NE; j++) {
-    uint32_t loc = static_cast<uint32_t>(ace.DLW()) + ace.xss<uint32_t>(i + 2 + 2 * NR + NE + j) - 1;
+    uint32_t loc = static_cast<uint32_t>(ace.DLW()) +
+                   ace.xss<uint32_t>(i + 2 + 2 * NR + NE + j) - 1;
     try {
       tables_.emplace_back(ace, loc);
     } catch (PNDLException& error) {
@@ -92,7 +93,8 @@ AngleEnergyPacket Kalbach::sample_angle_energy(
     l = incoming_energy_.size() - 2;
     f = 1.;
   } else {
-    l = static_cast<std::size_t>(std::distance(incoming_energy_.begin(), in_E_it) - 1);
+    l = static_cast<std::size_t>(
+        std::distance(incoming_energy_.begin(), in_E_it) - 1);
     f = (E_in - incoming_energy_[l]) /
         (incoming_energy_[l + 1] - incoming_energy_[l]);
   }
@@ -152,7 +154,8 @@ std::optional<double> Kalbach::angle_pdf(double E_in, double mu) const {
     l = incoming_energy_.size() - 2;
     f = 1.;
   } else {
-    l = static_cast<std::size_t>(std::distance(incoming_energy_.begin(), in_E_it) - 1);
+    l = static_cast<std::size_t>(
+        std::distance(incoming_energy_.begin(), in_E_it) - 1);
     f = (E_in - incoming_energy_[l]) /
         (incoming_energy_[l + 1] - incoming_energy_[l]);
   }
@@ -181,7 +184,8 @@ std::optional<double> Kalbach::pdf(double E_in, double mu, double E_out) const {
     l = incoming_energy_.size() - 2;
     f = 1.;
   } else {
-    l = static_cast<std::size_t>(std::distance(incoming_energy_.begin(), in_E_it) - 1);
+    l = static_cast<std::size_t>(
+        std::distance(incoming_energy_.begin(), in_E_it) - 1);
     f = (E_in - incoming_energy_[l]) /
         (incoming_energy_[l + 1] - incoming_energy_[l]);
   }

--- a/src/linearize.cpp
+++ b/src/linearize.cpp
@@ -66,8 +66,8 @@ Tabulated1D linearize(const std::vector<double>& i_x,
     const double rel_diff = std::abs((f_interp - f_real) / f_real);
     if (rel_diff > tolerance) {
       // Add the mid-point
-      auto xp = x.begin() + i + 1;
-      auto yp = y.begin() + i + 1;
+      auto xp = x.begin() + static_cast<std::ptrdiff_t>(i) + 1;
+      auto yp = y.begin() + static_cast<std::ptrdiff_t>(i) + 1;
       x.insert(xp, x_mid);
       y.insert(yp, f_real);
     } else {

--- a/src/mcnp_library.cpp
+++ b/src/mcnp_library.cpp
@@ -197,7 +197,7 @@ MCNPLibrary::MCNPLibrary(const std::string& fname) : NDLibrary(fname) {
 
     if (zaid_suffix == 'c') {
       // Continuous energy neutron data
-      uint32_t zaid_num = std::stoul(zaid_str);
+      uint32_t zaid_num = static_cast<uint32_t>(std::stoul(zaid_str));
       uint8_t Z = static_cast<uint8_t>(zaid_num / 1000);
       uint32_t A = zaid_num - (Z * 1000);
       ZAID zaid(Z, A);

--- a/src/mcnp_library.cpp
+++ b/src/mcnp_library.cpp
@@ -45,10 +45,10 @@ MCNPLibrary::MCNPLibrary(const std::string& fname) : NDLibrary(fname) {
   std::stringstream xsdir_stream;
   std::ifstream xsdir_file(xsdir_fname);
   xsdir_file.seekg(0, std::ios::end);
-  std::size_t xsdir_file_size = xsdir_file.tellg();
+  std::size_t xsdir_file_size = static_cast<std::size_t>(xsdir_file.tellg());
   std::string xsdir_buffer(xsdir_file_size, ' ');
   xsdir_file.seekg(0);
-  xsdir_file.read(&xsdir_buffer[0], xsdir_file_size);
+  xsdir_file.read(&xsdir_buffer[0], static_cast<std::streamsize>(xsdir_file_size));
 
   //------------------------------------------------------------------
   // Now try to read the atomic weight ratios

--- a/src/mcnp_library.cpp
+++ b/src/mcnp_library.cpp
@@ -48,7 +48,8 @@ MCNPLibrary::MCNPLibrary(const std::string& fname) : NDLibrary(fname) {
   std::size_t xsdir_file_size = static_cast<std::size_t>(xsdir_file.tellg());
   std::string xsdir_buffer(xsdir_file_size, ' ');
   xsdir_file.seekg(0);
-  xsdir_file.read(&xsdir_buffer[0], static_cast<std::streamsize>(xsdir_file_size));
+  xsdir_file.read(&xsdir_buffer[0],
+                  static_cast<std::streamsize>(xsdir_file_size));
 
   //------------------------------------------------------------------
   // Now try to read the atomic weight ratios

--- a/src/reaction.cpp
+++ b/src/reaction.cpp
@@ -35,8 +35,10 @@ Reaction<CrossSection>::Reaction(const ACE& ace, std::size_t indx,
                                  std::shared_ptr<EnergyGrid> egrid)
     : ReactionBase(ace, indx), xs_(nullptr) {
   try {
-    uint32_t loca = ace.xss<uint32_t>(static_cast<std::size_t>(ace.LSIG()) + indx);
-    xs_ = std::make_shared<CrossSection>(ace, static_cast<std::size_t>(ace.SIG()) + loca - 1, egrid);
+    uint32_t loca =
+        ace.xss<uint32_t>(static_cast<std::size_t>(ace.LSIG()) + indx);
+    xs_ = std::make_shared<CrossSection>(
+        ace, static_cast<std::size_t>(ace.SIG()) + loca - 1, egrid);
     threshold_ = xs_->energy(0);
   } catch (PNDLException& error) {
     std::string mssg = "Could not create cross section for MT = " +
@@ -58,8 +60,10 @@ Reaction<CrossSection>::Reaction(const ACE& ace, std::size_t indx,
 
   // Get XS from new ACE
   try {
-    uint32_t loca = ace.xss<uint32_t>(static_cast<std::size_t>(ace.LSIG()) + indx);
-    xs_ = std::make_shared<CrossSection>(ace, static_cast<std::size_t>(ace.SIG()) + loca - 1, egrid);
+    uint32_t loca =
+        ace.xss<uint32_t>(static_cast<std::size_t>(ace.LSIG()) + indx);
+    xs_ = std::make_shared<CrossSection>(
+        ace, static_cast<std::size_t>(ace.SIG()) + loca - 1, egrid);
     threshold_ = xs_->energy(0);
   } catch (PNDLException& error) {
     std::string mssg =

--- a/src/reaction.cpp
+++ b/src/reaction.cpp
@@ -35,8 +35,8 @@ Reaction<CrossSection>::Reaction(const ACE& ace, std::size_t indx,
                                  std::shared_ptr<EnergyGrid> egrid)
     : ReactionBase(ace, indx), xs_(nullptr) {
   try {
-    uint32_t loca = ace.xss<uint32_t>(ace.LSIG() + indx);
-    xs_ = std::make_shared<CrossSection>(ace, ace.SIG() + loca - 1, egrid);
+    uint32_t loca = ace.xss<uint32_t>(static_cast<std::size_t>(ace.LSIG()) + indx);
+    xs_ = std::make_shared<CrossSection>(ace, static_cast<std::size_t>(ace.SIG()) + loca - 1, egrid);
     threshold_ = xs_->energy(0);
   } catch (PNDLException& error) {
     std::string mssg = "Could not create cross section for MT = " +
@@ -58,8 +58,8 @@ Reaction<CrossSection>::Reaction(const ACE& ace, std::size_t indx,
 
   // Get XS from new ACE
   try {
-    uint32_t loca = ace.xss<uint32_t>(ace.LSIG() + indx);
-    xs_ = std::make_shared<CrossSection>(ace, ace.SIG() + loca - 1, egrid);
+    uint32_t loca = ace.xss<uint32_t>(static_cast<std::size_t>(ace.LSIG()) + indx);
+    xs_ = std::make_shared<CrossSection>(ace, static_cast<std::size_t>(ace.SIG()) + loca - 1, egrid);
     threshold_ = xs_->energy(0);
   } catch (PNDLException& error) {
     std::string mssg =

--- a/src/reaction_base.cpp
+++ b/src/reaction_base.cpp
@@ -54,21 +54,21 @@ ReactionBase::ReactionBase(const ACE& ace, std::size_t indx)
       yield_(nullptr),
       neutron_distribution_(nullptr) {
   // Get MT, Q, and AWR
-  mt_ = ace.xss<uint32_t>(ace.MTR() + indx);
-  q_ = ace.xss(ace.LQR() + indx);
+  mt_ = ace.xss<uint32_t>(static_cast<std::size_t>(ace.MTR()) + indx);
+  q_ = ace.xss(static_cast<std::size_t>(ace.LQR()) + indx);
   awr_ = ace.awr();
 
   // Determine the frame of reference for the outgoing distributions
   Frame frame_ = Frame::Lab;
-  if (ace.xss(ace.TYR() + indx) < 0.) frame_ = Frame::CM;
+  if (ace.xss(static_cast<std::size_t>(ace.TYR()) + indx) < 0.) frame_ = Frame::CM;
 
   // Get the yield for the reaction
-  double yld = std::abs(ace.xss(ace.TYR() + indx));
+  double yld = std::abs(ace.xss(static_cast<std::size_t>(ace.TYR()) + indx));
   try {
     if (yld < 100.)
       yield_ = std::make_shared<Constant>(yld);
     else {
-      std::size_t i = ace.DLW() + static_cast<uint32_t>(yld) - 101;
+      std::size_t i = static_cast<std::size_t>(ace.DLW()) + static_cast<std::size_t>(yld) - 101;
       uint32_t NR = ace.xss<uint32_t>(i);
       uint32_t NE = ace.xss<uint32_t>(i + 1 + 2 * NR);
       std::vector<double> energy = ace.xss(i + 2 + 2 * NR, NE);
@@ -162,7 +162,7 @@ void ReactionBase::load_neutron_distributions(
     std::vector<std::shared_ptr<AngleEnergy>>& distributions,
     std::vector<std::shared_ptr<Tabulated1D>>& probabilities) {
   // Get angle distribution location
-  int locb = ace.xss<int>(ace.LAND() + indx + 1);
+  int locb = ace.xss<int>(static_cast<std::size_t>(ace.LAND()) + indx + 1);
 
   std::shared_ptr<AngleDistribution> angle(nullptr);
 
@@ -180,8 +180,8 @@ void ReactionBase::load_neutron_distributions(
   }
 
   // Get energy distribution location
-  uint32_t locc = ace.xss<uint32_t>(ace.LDLW() + indx);
-  std::size_t i = ace.DLW() + locc - 1;
+  uint32_t locc = ace.xss<uint32_t>(static_cast<std::size_t>(ace.LDLW()) + indx);
+  std::size_t i = static_cast<std::size_t>(ace.DLW()) + locc - 1;
 
   // Location of next law (set any non-zero initial value)
   uint32_t lnw = 1;
@@ -191,7 +191,7 @@ void ReactionBase::load_neutron_distributions(
     // Get law info and location
     int law = ace.xss<int>(i + 1);
     uint32_t idat = ace.xss<uint32_t>(i + 2);
-    std::size_t j = ace.DLW() + idat - 1;
+    std::size_t j = static_cast<std::size_t>(ace.DLW()) + idat - 1;
 
     // Get probability for law
     std::shared_ptr<Tabulated1D> probability(nullptr);
@@ -276,7 +276,7 @@ void ReactionBase::load_neutron_distributions(
     probabilities.push_back(probability);
 
     // Get i for next distribution (if there is one)
-    i = ace.DLW() + lnw - 1;
+    i = static_cast<std::size_t>(ace.DLW()) + lnw - 1;
   }  // while lnw != 0
 }
 

--- a/src/reaction_base.cpp
+++ b/src/reaction_base.cpp
@@ -60,7 +60,8 @@ ReactionBase::ReactionBase(const ACE& ace, std::size_t indx)
 
   // Determine the frame of reference for the outgoing distributions
   Frame frame_ = Frame::Lab;
-  if (ace.xss(static_cast<std::size_t>(ace.TYR()) + indx) < 0.) frame_ = Frame::CM;
+  if (ace.xss(static_cast<std::size_t>(ace.TYR()) + indx) < 0.)
+    frame_ = Frame::CM;
 
   // Get the yield for the reaction
   double yld = std::abs(ace.xss(static_cast<std::size_t>(ace.TYR()) + indx));
@@ -68,7 +69,8 @@ ReactionBase::ReactionBase(const ACE& ace, std::size_t indx)
     if (yld < 100.)
       yield_ = std::make_shared<Constant>(yld);
     else {
-      std::size_t i = static_cast<std::size_t>(ace.DLW()) + static_cast<std::size_t>(yld) - 101;
+      std::size_t i = static_cast<std::size_t>(ace.DLW()) +
+                      static_cast<std::size_t>(yld) - 101;
       uint32_t NR = ace.xss<uint32_t>(i);
       uint32_t NE = ace.xss<uint32_t>(i + 1 + 2 * NR);
       std::vector<double> energy = ace.xss(i + 2 + 2 * NR, NE);
@@ -180,7 +182,8 @@ void ReactionBase::load_neutron_distributions(
   }
 
   // Get energy distribution location
-  uint32_t locc = ace.xss<uint32_t>(static_cast<std::size_t>(ace.LDLW()) + indx);
+  uint32_t locc =
+      ace.xss<uint32_t>(static_cast<std::size_t>(ace.LDLW()) + indx);
   std::size_t i = static_cast<std::size_t>(ace.DLW()) + locc - 1;
 
   // Location of next law (set any non-zero initial value)

--- a/src/serpent_library.cpp
+++ b/src/serpent_library.cpp
@@ -47,7 +47,8 @@ SerpentLibrary::SerpentLibrary(const std::string& fname) : NDLibrary(fname) {
   std::size_t xsdir_file_size = static_cast<std::size_t>(xsdir_file.tellg());
   std::string xsdir_buffer(xsdir_file_size, ' ');
   xsdir_file.seekg(0);
-  xsdir_file.read(&xsdir_buffer[0], static_cast<std::streamsize>(xsdir_file_size));
+  xsdir_file.read(&xsdir_buffer[0],
+                  static_cast<std::streamsize>(xsdir_file_size));
   std::stringstream xsdir_stream(xsdir_buffer);
 
   // Read the xsdir line by line

--- a/src/serpent_library.cpp
+++ b/src/serpent_library.cpp
@@ -89,7 +89,7 @@ SerpentLibrary::SerpentLibrary(const std::string& fname) : NDLibrary(fname) {
 
     if (type_str[0] == '1') {
       // Continuous Energy Neutron data
-      uint32_t ZA = std::stoul(ZA_str);
+      uint32_t ZA = static_cast<uint32_t>(std::stoul(ZA_str));
       uint8_t Z = static_cast<uint8_t>(ZA / 1000);
       uint32_t A = ZA - (Z * 1000);
       ZAID zaid(Z, A);

--- a/src/serpent_library.cpp
+++ b/src/serpent_library.cpp
@@ -44,10 +44,10 @@ SerpentLibrary::SerpentLibrary(const std::string& fname) : NDLibrary(fname) {
   // First, read the entire file into a string
   std::ifstream xsdir_file(xsdir_fname);
   xsdir_file.seekg(0, std::ios::end);
-  std::size_t xsdir_file_size = xsdir_file.tellg();
+  std::size_t xsdir_file_size = static_cast<std::size_t>(xsdir_file.tellg());
   std::string xsdir_buffer(xsdir_file_size, ' ');
   xsdir_file.seekg(0);
-  xsdir_file.read(&xsdir_buffer[0], xsdir_file_size);
+  xsdir_file.read(&xsdir_buffer[0], static_cast<std::streamsize>(xsdir_file_size));
   std::stringstream xsdir_stream(xsdir_buffer);
 
   // Read the xsdir line by line

--- a/src/st_coherent_elastic.cpp
+++ b/src/st_coherent_elastic.cpp
@@ -33,7 +33,7 @@ STCoherentElastic::STCoherentElastic(const ACE& ace)
   int32_t elastic_mode = ace.nxs(4);
   if (elastic_mode == 4) {
     // Get index to Bragg edge and structure data
-    int32_t i = ace.jxs(3) - 1;
+    std::size_t i = static_cast<std::size_t>(ace.jxs(3) - 1);
     uint32_t Ne = ace.xss<uint32_t>(i);
     bragg_edges_ = ace.xss(i + 1, Ne);
     structure_factor_sum_ = ace.xss(i + 1 + Ne, Ne);

--- a/src/st_incoherent_elastic_ace.cpp
+++ b/src/st_incoherent_elastic_ace.cpp
@@ -37,7 +37,7 @@ STIncoherentElasticACE::STIncoherentElasticACE(const ACE& ace)
     xs_ = std::make_shared<Tabulated1D>(Interpolation::Histogram, E, xs_vals);
   } else {
     // Get index to incident energy
-    int32_t i = ace.jxs(3) - 1;
+    std::size_t i = static_cast<std::size_t>(ace.jxs(3) - 1);
     uint32_t Ne = ace.xss<uint32_t>(i);
     incoming_energy_ = ace.xss(i + 1, Ne);
     std::vector<double> xs_vals = ace.xss(i + 1 + Ne, Ne);
@@ -56,7 +56,7 @@ STIncoherentElasticACE::STIncoherentElasticACE(const ACE& ace)
 
     // Read scattering cosines
     Nmu = static_cast<uint32_t>(ace.nxs(5) + 1);
-    i = ace.jxs(5) - 1;
+    i = static_cast<std::size_t>(ace.jxs(5) - 1);
     for (size_t ie = 0; ie < Ne; ie++) {
       std::vector<double> cosines_for_ie = ace.xss(i, Nmu);
       i += Nmu;

--- a/src/st_incoherent_inelastic.cpp
+++ b/src/st_incoherent_inelastic.cpp
@@ -32,7 +32,7 @@ STIncoherentInelastic::STIncoherentInelastic(const ACE& ace,
     : xs_(nullptr), angle_energy_(nullptr) {
   // Read the XS
   try {
-    int32_t S = ace.jxs(0) - 1;
+    std::size_t S = static_cast<std::size_t>(ace.jxs(0) - 1);
     uint32_t Ne = ace.xss<uint32_t>(S);  // Number of grid points
     std::vector<double> energy = ace.xss(S + 1, Ne);
     std::vector<double> xs = ace.xss(S + 1 + Ne, Ne);

--- a/src/st_neutron.cpp
+++ b/src/st_neutron.cpp
@@ -50,11 +50,15 @@ STNeutron::STNeutron(const ACE& ace)
 
   // Number of energy points
   uint32_t NE = static_cast<uint32_t>(ace.nxs(2));
-  total_xs_ =
-    std::make_shared<CrossSection>(ace, static_cast<std::size_t>(ace.ESZ()) + NE, energy_grid_, false);
-  disappearance_xs_ = std::make_shared<CrossSection>(ace, static_cast<std::size_t>(ace.ESZ()) + 2 * NE, energy_grid_, false);
-  elastic_xs_ = std::make_shared<CrossSection>(ace, static_cast<std::size_t>(ace.ESZ()) + 3 * NE, energy_grid_, false);
-  heating_number_ = std::make_shared<CrossSection>(ace, static_cast<std::size_t>(ace.ESZ()) + 4 * NE, energy_grid_, false, true);
+  total_xs_ = std::make_shared<CrossSection>(
+      ace, static_cast<std::size_t>(ace.ESZ()) + NE, energy_grid_, false);
+  disappearance_xs_ = std::make_shared<CrossSection>(
+      ace, static_cast<std::size_t>(ace.ESZ()) + 2 * NE, energy_grid_, false);
+  elastic_xs_ = std::make_shared<CrossSection>(
+      ace, static_cast<std::size_t>(ace.ESZ()) + 3 * NE, energy_grid_, false);
+  heating_number_ = std::make_shared<CrossSection>(
+      ace, static_cast<std::size_t>(ace.ESZ()) + 4 * NE, energy_grid_, false,
+      true);
 
   // Get photon production XS if present
   if (ace.jxs(11) != 0) {
@@ -84,7 +88,9 @@ STNeutron::STNeutron(const ACE& ace)
   try {
     elastic_ = std::make_shared<Elastic>(
         std::make_shared<ElasticSVT>(),
-        AngleDistribution(ace, ace.xss<int>(static_cast<std::size_t>(ace.LAND()))), awr_, temperature_);
+        AngleDistribution(ace,
+                          ace.xss<int>(static_cast<std::size_t>(ace.LAND()))),
+        awr_, temperature_);
   } catch (PNDLException& err) {
     std::string mssg = "Could not create Elastic AngleEnergy distribution.";
     err.add_to_exception(mssg);
@@ -148,10 +154,15 @@ STNeutron::STNeutron(const ACE& ace, const STNeutron& nuclide)
 
   // Number of energy points
   uint32_t NE = static_cast<uint32_t>(ace.nxs(2));
-  total_xs_ = std::make_shared<CrossSection>(ace, static_cast<std::size_t>(ace.ESZ()) + NE, energy_grid_, false);
-  disappearance_xs_ = std::make_shared<CrossSection>(ace, static_cast<std::size_t>(ace.ESZ()) + 2 * NE, energy_grid_, false);
-  elastic_xs_ = std::make_shared<CrossSection>(ace, static_cast<std::size_t>(ace.ESZ()) + 3 * NE, energy_grid_, false);
-  heating_number_ = std::make_shared<CrossSection>(ace, static_cast<std::size_t>(ace.ESZ()) + 4 * NE, energy_grid_, false, true);
+  total_xs_ = std::make_shared<CrossSection>(
+      ace, static_cast<std::size_t>(ace.ESZ()) + NE, energy_grid_, false);
+  disappearance_xs_ = std::make_shared<CrossSection>(
+      ace, static_cast<std::size_t>(ace.ESZ()) + 2 * NE, energy_grid_, false);
+  elastic_xs_ = std::make_shared<CrossSection>(
+      ace, static_cast<std::size_t>(ace.ESZ()) + 3 * NE, energy_grid_, false);
+  heating_number_ = std::make_shared<CrossSection>(
+      ace, static_cast<std::size_t>(ace.ESZ()) + 4 * NE, energy_grid_, false,
+      true);
 
   // Get photon production XS if present
   if (ace.jxs(11) != 0) {
@@ -171,9 +182,9 @@ STNeutron::STNeutron(const ACE& ace, const STNeutron& nuclide)
     uint32_t MT = ace.xss<uint32_t>(static_cast<std::size_t>(ace.MTR()) + indx);
     if (MT != 18 && MT != 19 && MT != 20 && MT != 21 && MT != 38) {
       mt_list_.push_back(MT);
-      reactions_.emplace_back(
-          ace, indx, energy_grid_,
-          nuclide.reactions_[static_cast<std::size_t>(nuclide.reaction_indices_[MT])]);
+      reactions_.emplace_back(ace, indx, energy_grid_,
+                              nuclide.reactions_[static_cast<std::size_t>(
+                                  nuclide.reaction_indices_[MT])]);
       reaction_indices_[MT] = current_reaction_index;
       current_reaction_index++;
     }

--- a/src/st_neutron.cpp
+++ b/src/st_neutron.cpp
@@ -49,15 +49,12 @@ STNeutron::STNeutron(const ACE& ace)
   energy_grid_ = std::make_shared<EnergyGrid>(ace);
 
   // Number of energy points
-  uint32_t NE = ace.nxs(2);
+  uint32_t NE = static_cast<uint32_t>(ace.nxs(2));
   total_xs_ =
-      std::make_shared<CrossSection>(ace, ace.ESZ() + NE, energy_grid_, false);
-  disappearance_xs_ = std::make_shared<CrossSection>(ace, ace.ESZ() + 2 * NE,
-                                                     energy_grid_, false);
-  elastic_xs_ = std::make_shared<CrossSection>(ace, ace.ESZ() + 3 * NE,
-                                               energy_grid_, false);
-  heating_number_ = std::make_shared<CrossSection>(ace, ace.ESZ() + 4 * NE,
-                                                   energy_grid_, false, true);
+    std::make_shared<CrossSection>(ace, static_cast<std::size_t>(ace.ESZ()) + NE, energy_grid_, false);
+  disappearance_xs_ = std::make_shared<CrossSection>(ace, static_cast<std::size_t>(ace.ESZ()) + 2 * NE, energy_grid_, false);
+  elastic_xs_ = std::make_shared<CrossSection>(ace, static_cast<std::size_t>(ace.ESZ()) + 3 * NE, energy_grid_, false);
+  heating_number_ = std::make_shared<CrossSection>(ace, static_cast<std::size_t>(ace.ESZ()) + 4 * NE, energy_grid_, false, true);
 
   // Get photon production XS if present
   if (ace.jxs(11) != 0) {
@@ -68,13 +65,13 @@ STNeutron::STNeutron(const ACE& ace)
   }
 
   // Read all reactions
-  uint32_t NMT = ace.nxs(3);
+  uint32_t NMT = static_cast<uint32_t>(ace.nxs(3));
   reaction_indices_.fill(-1);
   int32_t current_reaction_index = 0;
   mt_list_.reserve(NMT);
   reactions_.reserve(NMT);
   for (uint32_t indx = 0; indx < NMT; indx++) {
-    uint32_t MT = ace.xss<uint32_t>(ace.MTR() + indx);
+    uint32_t MT = ace.xss<uint32_t>(static_cast<std::size_t>(ace.MTR()) + indx);
     if (MT != 18 && MT != 19 && MT != 20 && MT != 21 && MT != 38) {
       mt_list_.push_back(MT);
       reactions_.emplace_back(ace, indx, energy_grid_);
@@ -87,7 +84,7 @@ STNeutron::STNeutron(const ACE& ace)
   try {
     elastic_ = std::make_shared<Elastic>(
         std::make_shared<ElasticSVT>(),
-        AngleDistribution(ace, ace.xss<int>(ace.LAND())), awr_, temperature_);
+        AngleDistribution(ace, ace.xss<int>(static_cast<std::size_t>(ace.LAND()))), awr_, temperature_);
   } catch (PNDLException& err) {
     std::string mssg = "Could not create Elastic AngleEnergy distribution.";
     err.add_to_exception(mssg);
@@ -150,15 +147,11 @@ STNeutron::STNeutron(const ACE& ace, const STNeutron& nuclide)
   energy_grid_ = std::make_shared<EnergyGrid>(ace);
 
   // Number of energy points
-  uint32_t NE = ace.nxs(2);
-  total_xs_ =
-      std::make_shared<CrossSection>(ace, ace.ESZ() + NE, energy_grid_, false);
-  disappearance_xs_ = std::make_shared<CrossSection>(ace, ace.ESZ() + 2 * NE,
-                                                     energy_grid_, false);
-  elastic_xs_ = std::make_shared<CrossSection>(ace, ace.ESZ() + 3 * NE,
-                                               energy_grid_, false);
-  heating_number_ = std::make_shared<CrossSection>(ace, ace.ESZ() + 4 * NE,
-                                                   energy_grid_, false, true);
+  uint32_t NE = static_cast<uint32_t>(ace.nxs(2));
+  total_xs_ = std::make_shared<CrossSection>(ace, static_cast<std::size_t>(ace.ESZ()) + NE, energy_grid_, false);
+  disappearance_xs_ = std::make_shared<CrossSection>(ace, static_cast<std::size_t>(ace.ESZ()) + 2 * NE, energy_grid_, false);
+  elastic_xs_ = std::make_shared<CrossSection>(ace, static_cast<std::size_t>(ace.ESZ()) + 3 * NE, energy_grid_, false);
+  heating_number_ = std::make_shared<CrossSection>(ace, static_cast<std::size_t>(ace.ESZ()) + 4 * NE, energy_grid_, false, true);
 
   // Get photon production XS if present
   if (ace.jxs(11) != 0) {
@@ -169,18 +162,18 @@ STNeutron::STNeutron(const ACE& ace, const STNeutron& nuclide)
   }
 
   // Read all reactions
-  uint32_t NMT = ace.nxs(3);
+  uint32_t NMT = static_cast<uint32_t>(ace.nxs(3));
   reaction_indices_.fill(-1);
   int32_t current_reaction_index = 0;
   mt_list_.resize(NMT, 0);
   reactions_.reserve(NMT);
   for (uint32_t indx = 0; indx < NMT; indx++) {
-    uint32_t MT = ace.xss<uint32_t>(ace.MTR() + indx);
+    uint32_t MT = ace.xss<uint32_t>(static_cast<std::size_t>(ace.MTR()) + indx);
     if (MT != 18 && MT != 19 && MT != 20 && MT != 21 && MT != 38) {
       mt_list_.push_back(MT);
       reactions_.emplace_back(
           ace, indx, energy_grid_,
-          nuclide.reactions_[nuclide.reaction_indices_[MT]]);
+          nuclide.reactions_[static_cast<std::size_t>(nuclide.reaction_indices_[MT])]);
       reaction_indices_[MT] = current_reaction_index;
       current_reaction_index++;
     }

--- a/src/tabular_energy.cpp
+++ b/src/tabular_energy.cpp
@@ -86,7 +86,7 @@ double TabularEnergy::sample_energy(double E_in,
     l = incoming_energy_.size() - 2;
     f = 1.;
   } else {
-    l = std::distance(incoming_energy_.begin(), in_E_it) - 1;
+    l = static_cast<std::size_t>(std::distance(incoming_energy_.begin(), in_E_it) - 1);
     f = (E_in - incoming_energy_[l]) /
         (incoming_energy_[l + 1] - incoming_energy_[l]);
   }
@@ -129,7 +129,7 @@ std::optional<double> TabularEnergy::pdf(double E_in, double E_out) const {
     l = incoming_energy_.size() - 2;
     f = 1.;
   } else {
-    l = std::distance(incoming_energy_.begin(), in_E_it) - 1;
+    l = static_cast<std::size_t>(std::distance(incoming_energy_.begin(), in_E_it) - 1);
     f = (E_in - incoming_energy_[l]) /
         (incoming_energy_[l + 1] - incoming_energy_[l]);
   }

--- a/src/tabular_energy.cpp
+++ b/src/tabular_energy.cpp
@@ -86,7 +86,8 @@ double TabularEnergy::sample_energy(double E_in,
     l = incoming_energy_.size() - 2;
     f = 1.;
   } else {
-    l = static_cast<std::size_t>(std::distance(incoming_energy_.begin(), in_E_it) - 1);
+    l = static_cast<std::size_t>(
+        std::distance(incoming_energy_.begin(), in_E_it) - 1);
     f = (E_in - incoming_energy_[l]) /
         (incoming_energy_[l + 1] - incoming_energy_[l]);
   }
@@ -129,7 +130,8 @@ std::optional<double> TabularEnergy::pdf(double E_in, double E_out) const {
     l = incoming_energy_.size() - 2;
     f = 1.;
   } else {
-    l = static_cast<std::size_t>(std::distance(incoming_energy_.begin(), in_E_it) - 1);
+    l = static_cast<std::size_t>(
+        std::distance(incoming_energy_.begin(), in_E_it) - 1);
     f = (E_in - incoming_energy_[l]) /
         (incoming_energy_[l + 1] - incoming_energy_[l]);
   }

--- a/src/tabular_energy_angle.cpp
+++ b/src/tabular_energy_angle.cpp
@@ -48,7 +48,8 @@ TabularEnergyAngle::TabularEnergyAngle(const ACE& ace, std::size_t i,
 
   // Read outgoing energy tables
   for (uint32_t j = 0; j < NE; j++) {
-    uint32_t loc = static_cast<uint32_t>(ace.DLW()) + ace.xss<uint32_t>(i + 2 + 2 * NR + NE + j) - 1;
+    uint32_t loc = static_cast<uint32_t>(ace.DLW()) +
+                   ace.xss<uint32_t>(i + 2 + 2 * NR + NE + j) - 1;
     try {
       tables_.emplace_back(ace, loc, JED);
     } catch (PNDLException& error) {
@@ -94,7 +95,8 @@ AngleEnergyPacket TabularEnergyAngle::sample_angle_energy(
     l = incoming_energy_.size() - 2;
     f = 1.;
   } else {
-    l = static_cast<std::size_t>(std::distance(incoming_energy_.begin(), in_E_it) - 1);
+    l = static_cast<std::size_t>(
+        std::distance(incoming_energy_.begin(), in_E_it) - 1);
     f = (E_in - incoming_energy_[l]) /
         (incoming_energy_[l + 1] - incoming_energy_[l]);
   }
@@ -145,7 +147,8 @@ std::optional<double> TabularEnergyAngle::angle_pdf(double E_in,
     l = incoming_energy_.size() - 2;
     f = 1.;
   } else {
-    l = static_cast<std::size_t>(std::distance(incoming_energy_.begin(), in_E_it) - 1);
+    l = static_cast<std::size_t>(
+        std::distance(incoming_energy_.begin(), in_E_it) - 1);
     f = (E_in - incoming_energy_[l]) /
         (incoming_energy_[l + 1] - incoming_energy_[l]);
   }
@@ -175,7 +178,8 @@ std::optional<double> TabularEnergyAngle::pdf(double E_in, double mu,
     l = incoming_energy_.size() - 2;
     f = 1.;
   } else {
-    l = static_cast<std::size_t>(std::distance(incoming_energy_.begin(), in_E_it) - 1);
+    l = static_cast<std::size_t>(
+        std::distance(incoming_energy_.begin(), in_E_it) - 1);
     f = (E_in - incoming_energy_[l]) /
         (incoming_energy_[l + 1] - incoming_energy_[l]);
   }

--- a/src/tabular_energy_angle.cpp
+++ b/src/tabular_energy_angle.cpp
@@ -48,7 +48,7 @@ TabularEnergyAngle::TabularEnergyAngle(const ACE& ace, std::size_t i,
 
   // Read outgoing energy tables
   for (uint32_t j = 0; j < NE; j++) {
-    uint32_t loc = ace.DLW() + ace.xss<uint32_t>(i + 2 + 2 * NR + NE + j) - 1;
+    uint32_t loc = static_cast<uint32_t>(ace.DLW()) + ace.xss<uint32_t>(i + 2 + 2 * NR + NE + j) - 1;
     try {
       tables_.emplace_back(ace, loc, JED);
     } catch (PNDLException& error) {
@@ -94,7 +94,7 @@ AngleEnergyPacket TabularEnergyAngle::sample_angle_energy(
     l = incoming_energy_.size() - 2;
     f = 1.;
   } else {
-    l = std::distance(incoming_energy_.begin(), in_E_it) - 1;
+    l = static_cast<std::size_t>(std::distance(incoming_energy_.begin(), in_E_it) - 1);
     f = (E_in - incoming_energy_[l]) /
         (incoming_energy_[l + 1] - incoming_energy_[l]);
   }
@@ -145,7 +145,7 @@ std::optional<double> TabularEnergyAngle::angle_pdf(double E_in,
     l = incoming_energy_.size() - 2;
     f = 1.;
   } else {
-    l = std::distance(incoming_energy_.begin(), in_E_it) - 1;
+    l = static_cast<std::size_t>(std::distance(incoming_energy_.begin(), in_E_it) - 1);
     f = (E_in - incoming_energy_[l]) /
         (incoming_energy_[l + 1] - incoming_energy_[l]);
   }
@@ -175,7 +175,7 @@ std::optional<double> TabularEnergyAngle::pdf(double E_in, double mu,
     l = incoming_energy_.size() - 2;
     f = 1.;
   } else {
-    l = std::distance(incoming_energy_.begin(), in_E_it) - 1;
+    l = static_cast<std::size_t>(std::distance(incoming_energy_.begin(), in_E_it) - 1);
     f = (E_in - incoming_energy_[l]) /
         (incoming_energy_[l + 1] - incoming_energy_[l]);
   }

--- a/src/tabulated_1d.cpp
+++ b/src/tabulated_1d.cpp
@@ -60,9 +60,12 @@ Tabulated1D::Tabulated1D(const std::vector<uint32_t>& NBT,
     hi = breakpoints_[i];
 
     try {
-      regions_.push_back(InterpolationRange(
-                                            interpolation_[i], {x_.begin() + static_cast<std::ptrdiff_t>(low), x_.begin() + static_cast<std::ptrdiff_t>(hi)},
-                                            {y_.begin() + static_cast<std::ptrdiff_t>(low), y_.begin() + static_cast<std::ptrdiff_t>(hi)}));
+      regions_.push_back(
+          InterpolationRange(interpolation_[i],
+                             {x_.begin() + static_cast<std::ptrdiff_t>(low),
+                              x_.begin() + static_cast<std::ptrdiff_t>(hi)},
+                             {y_.begin() + static_cast<std::ptrdiff_t>(low),
+                              y_.begin() + static_cast<std::ptrdiff_t>(hi)}));
     } catch (PNDLException& error) {
       std::string mssg = "The i = " + std::to_string(i) +
                          " InterpolationRange could not be constructed when "
@@ -101,9 +104,10 @@ Tabulated1D::Tabulated1D(Interpolation interp, const std::vector<double>& x,
   // Make 1 1D region
   const std::size_t hi = breakpoints_[0];
   try {
-    regions_.push_back(InterpolationRange(interpolation_[0],
-                                          {x_.begin(), x_.begin() + static_cast<std::ptrdiff_t>(hi)},
-                                          {y_.begin(), y_.begin() + static_cast<std::ptrdiff_t>(hi)}));
+    regions_.push_back(InterpolationRange(
+        interpolation_[0],
+        {x_.begin(), x_.begin() + static_cast<std::ptrdiff_t>(hi)},
+        {y_.begin(), y_.begin() + static_cast<std::ptrdiff_t>(hi)}));
   } catch (PNDLException& error) {
     std::string mssg =
         "The InterpolationRange could not be constructed when building "

--- a/src/tabulated_1d.cpp
+++ b/src/tabulated_1d.cpp
@@ -23,6 +23,7 @@
 #include <PapillonNDL/linearize.hpp>
 #include <PapillonNDL/pndl_exception.hpp>
 #include <PapillonNDL/tabulated_1d.hpp>
+#include <cstddef>
 #include <cstdint>
 
 namespace pndl {
@@ -60,8 +61,8 @@ Tabulated1D::Tabulated1D(const std::vector<uint32_t>& NBT,
 
     try {
       regions_.push_back(InterpolationRange(
-          interpolation_[i], {x_.begin() + low, x_.begin() + hi},
-          {y_.begin() + low, y_.begin() + hi}));
+                                            interpolation_[i], {x_.begin() + static_cast<std::ptrdiff_t>(low), x_.begin() + static_cast<std::ptrdiff_t>(hi)},
+                                            {y_.begin() + static_cast<std::ptrdiff_t>(low), y_.begin() + static_cast<std::ptrdiff_t>(hi)}));
     } catch (PNDLException& error) {
       std::string mssg = "The i = " + std::to_string(i) +
                          " InterpolationRange could not be constructed when "
@@ -101,8 +102,8 @@ Tabulated1D::Tabulated1D(Interpolation interp, const std::vector<double>& x,
   const std::size_t hi = breakpoints_[0];
   try {
     regions_.push_back(InterpolationRange(interpolation_[0],
-                                          {x_.begin(), x_.begin() + hi},
-                                          {y_.begin(), y_.begin() + hi}));
+                                          {x_.begin(), x_.begin() + static_cast<std::ptrdiff_t>(hi)},
+                                          {y_.begin(), y_.begin() + static_cast<std::ptrdiff_t>(hi)}));
   } catch (PNDLException& error) {
     std::string mssg =
         "The InterpolationRange could not be constructed when building "

--- a/src/urr_ptables.cpp
+++ b/src/urr_ptables.cpp
@@ -63,18 +63,18 @@ URRPTables::URRPTables(const ACE& ace, const CrossSection& total,
   }
 
   // Read numbers and flags
-  uint32_t Nenergy = ace.xss<uint32_t>(ace.LUNR());
-  uint32_t Nptables = ace.xss<uint32_t>(ace.LUNR() + 1);
-  interp_ = ace.xss<Interpolation>(ace.LUNR() + 2);
-  int32_t inelastic_flag = ace.xss<int32_t>(ace.LUNR() + 3);
-  int32_t absorption_flag = ace.xss<int32_t>(ace.LUNR() + 4);
-  int32_t factors_flag = ace.xss<int32_t>(ace.LUNR() + 5);
+  uint32_t Nenergy = ace.xss<uint32_t>(static_cast<std::size_t>(ace.LUNR()));
+  uint32_t Nptables = ace.xss<uint32_t>(static_cast<std::size_t>(ace.LUNR()) + 1);
+  interp_ = ace.xss<Interpolation>(static_cast<std::size_t>(ace.LUNR()) + 2);
+  int32_t inelastic_flag = ace.xss<int32_t>(static_cast<std::size_t>(ace.LUNR()) + 3);
+  int32_t absorption_flag = ace.xss<int32_t>(static_cast<std::size_t>(ace.LUNR()) + 4);
+  int32_t factors_flag = ace.xss<int32_t>(static_cast<std::size_t>(ace.LUNR()) + 5);
 
   // Read energy grid
-  *energy_ = ace.xss(ace.LUNR() + 6, Nenergy);
+  *energy_ = ace.xss(static_cast<std::size_t>(ace.LUNR()) + 6, Nenergy);
 
   // Read all PTables for each energy
-  std::size_t indx = ace.LUNR() + 6 + Nenergy;
+  std::size_t indx = static_cast<std::size_t>(ace.LUNR()) + 6 + Nenergy;
   PTable empty_ptable;
   for (std::size_t ie = 0; ie < Nenergy; ie++) {
     ptables_->push_back(empty_ptable);

--- a/src/urr_ptables.cpp
+++ b/src/urr_ptables.cpp
@@ -64,11 +64,15 @@ URRPTables::URRPTables(const ACE& ace, const CrossSection& total,
 
   // Read numbers and flags
   uint32_t Nenergy = ace.xss<uint32_t>(static_cast<std::size_t>(ace.LUNR()));
-  uint32_t Nptables = ace.xss<uint32_t>(static_cast<std::size_t>(ace.LUNR()) + 1);
+  uint32_t Nptables =
+      ace.xss<uint32_t>(static_cast<std::size_t>(ace.LUNR()) + 1);
   interp_ = ace.xss<Interpolation>(static_cast<std::size_t>(ace.LUNR()) + 2);
-  int32_t inelastic_flag = ace.xss<int32_t>(static_cast<std::size_t>(ace.LUNR()) + 3);
-  int32_t absorption_flag = ace.xss<int32_t>(static_cast<std::size_t>(ace.LUNR()) + 4);
-  int32_t factors_flag = ace.xss<int32_t>(static_cast<std::size_t>(ace.LUNR()) + 5);
+  int32_t inelastic_flag =
+      ace.xss<int32_t>(static_cast<std::size_t>(ace.LUNR()) + 3);
+  int32_t absorption_flag =
+      ace.xss<int32_t>(static_cast<std::size_t>(ace.LUNR()) + 4);
+  int32_t factors_flag =
+      ace.xss<int32_t>(static_cast<std::size_t>(ace.LUNR()) + 5);
 
   // Read energy grid
   *energy_ = ace.xss(static_cast<std::size_t>(ace.LUNR()) + 6, Nenergy);


### PR DESCRIPTION
I have decided to add the `-Wconversion` flag when building with GCC or Clang. This PR adds this private compilation flag to the library, and also fixes all the new compilation warnings due to the new flag.