### PR TITLE
Fix Variable Shadow Warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,11 +100,11 @@ target_compile_features(PapillonNDL PUBLIC cxx_std_20)
 if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC") # Comile options for Windows
   target_compile_options(PapillonNDL PRIVATE /W4)
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU") # Compile options for GCC
-  target_compile_options(PapillonNDL PRIVATE -W -Wall -Wextra -Wconversion -Wpedantic)
+  target_compile_options(PapillonNDL PRIVATE -W -Wall -Wextra -Wconversion -Wshadow -Wpedantic)
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang") # Compile options for Clang
-  target_compile_options(PapillonNDL PRIVATE -W -Wall -Wextra -Wconversion -Wpedantic)
+  target_compile_options(PapillonNDL PRIVATE -W -Wall -Wextra -Wconversion -Wshadow -Wpedantic)
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Intel") # Compile options for Intel
-  target_compile_options(PapillonNDL PRIVATE -W -Wall -Wextra -Wconversion -Wpedantic)
+  target_compile_options(PapillonNDL PRIVATE -W -Wall -Wextra -Wconversion -Wshadow -Wpedantic)
 endif()
 
 # Must make the static PapillonNDL position independent on linux so that

--- a/include/PapillonNDL/discrete_photon.hpp
+++ b/include/PapillonNDL/discrete_photon.hpp
@@ -70,11 +70,11 @@ class DiscretePhoton : public EnergyLaw {
   }
 
   /**
-   * @param lp Primary indicator flag (0 or 1 is primary, 2 is secondary).
-   * @param Eg Energy argument of distribution.
+   * @param l Primary indicator flag (0 or 1 is primary, 2 is secondary).
+   * @param E Energy argument of distribution.
    * @param AWR Atomic Weight Ratio of nuclide.
    */
-  DiscretePhoton(int lp, double Eg, double AWR) : lp(lp), A(AWR), Eg(Eg) {
+  DiscretePhoton(int l, double E, double AWR) : lp(l), A(AWR), Eg(E) {
     if ((lp != 0) && (lp != 1) && (lp != 2)) {
       std::string mssg = "Invalid lp of " + std::to_string(lp) + ".";
       throw PNDLException(mssg);

--- a/include/PapillonNDL/kalbach_table.hpp
+++ b/include/PapillonNDL/kalbach_table.hpp
@@ -149,8 +149,7 @@ class KalbachTable {
 
     for (std::size_t i = 0; i < pdf_.size() - 1; i++) {
       if (interp_ == Interpolation::Histogram) {
-        pdf_out +=
-            mu_p(A_[i], R_[i]) * pdf_[i] * (energy_[i + 1] - energy_[i]);
+        pdf_out += mu_p(A_[i], R_[i]) * pdf_[i] * (energy_[i + 1] - energy_[i]);
       } else {
         pdf_out += 0.5 * (energy_[i + 1] - energy_[i]) *
                    (mu_p(A_[i], R_[i]) * pdf_[i] +

--- a/include/PapillonNDL/kalbach_table.hpp
+++ b/include/PapillonNDL/kalbach_table.hpp
@@ -140,7 +140,7 @@ class KalbachTable {
    * @param mu Cosine of scattering angle.
    */
   double angle_pdf(double mu) const {
-    auto mu_p = [](double a, double r, double mu) {
+    auto mu_p = [mu](double a, double r) {
       return 0.5 * (a / std::sinh(a)) *
              (std::cosh(a * mu) + r * std::sinh(a * mu));
     };
@@ -150,11 +150,11 @@ class KalbachTable {
     for (std::size_t i = 0; i < pdf_.size() - 1; i++) {
       if (interp_ == Interpolation::Histogram) {
         pdf_out +=
-            mu_p(A_[i], R_[i], mu) * pdf_[i] * (energy_[i + 1] - energy_[i]);
+            mu_p(A_[i], R_[i]) * pdf_[i] * (energy_[i + 1] - energy_[i]);
       } else {
         pdf_out += 0.5 * (energy_[i + 1] - energy_[i]) *
-                   (mu_p(A_[i], R_[i], mu) * pdf_[i] +
-                    mu_p(A_[i + 1], R_[i + 1], mu) * pdf_[i + 1]);
+                   (mu_p(A_[i], R_[i]) * pdf_[i] +
+                    mu_p(A_[i + 1], R_[i + 1]) * pdf_[i + 1]);
       }
     }
 
@@ -168,7 +168,7 @@ class KalbachTable {
    * @param E_out Exit energy.
    */
   double pdf(double mu, double E_out) const {
-    auto mu_p = [](double a, double r, double mu) {
+    auto mu_p = [mu](double a, double r) {
       return 0.5 * (a / std::sinh(a)) *
              (std::cosh(a * mu) + r * std::sinh(a * mu));
     };
@@ -184,15 +184,15 @@ class KalbachTable {
     if (E_out != *E_it) l--;
 
     if (interp_ == Interpolation::Histogram) {
-      double mu_pdf = mu_p(A_[l], R_[l], mu);
+      double mu_pdf = mu_p(A_[l], R_[l]);
       double E_pdf = pdf_[l];
       return mu_pdf * E_pdf;
     } else {
       double f = (E_out - energy_[l]) / (energy_[l + 1] - energy_[l]);
       double out_pdf = 0;
 
-      out_pdf += f * mu_p(A_[l + 1], R_[l + 1], mu) * pdf_[l + 1];
-      out_pdf += (1. - f) * mu_p(A_[l], R_[l], mu) * pdf_[l];
+      out_pdf += f * mu_p(A_[l + 1], R_[l + 1]) * pdf_[l + 1];
+      out_pdf += (1. - f) * mu_p(A_[l], R_[l]) * pdf_[l];
 
       return out_pdf;
     }

--- a/src/vector.hpp
+++ b/src/vector.hpp
@@ -32,7 +32,7 @@ namespace pndl {
 struct Vector {
   double x, y, z;
 
-  Vector(double x, double y, double z) : x(x), y(y), z(z) {}
+  Vector(double ix, double iy, double iz) : x(ix), y(iy), z(iz) {}
   Vector(const std::array<double, 3>& vals)
       : x(vals[0]), y(vals[1]), z(vals[2]) {}
 


### PR DESCRIPTION
This PR adds `-Wshadow` as a compilation flag for GCC/Clang, and also fixes the warnings which appeared as a result. This should be the last new warning flag.