### PR TITLE
Fix possible negative argument in square root function when interpolating distributions

### DIFF
--- a/include/PapillonNDL/energy_angle_table.hpp
+++ b/include/PapillonNDL/energy_angle_table.hpp
@@ -212,11 +212,10 @@ class EnergyAngleTable {
   }
 
   double linear_interp_energy(double xi, std::size_t l) const {
-    double m = (pdf_[l + 1] - pdf_[l]) / (energy_[l + 1] - energy_[l]);
+    const double m = (pdf_[l + 1] - pdf_[l]) / (energy_[l + 1] - energy_[l]);
+    const double arg = pdf_[l] * pdf_[l] + 2. * m * (xi - cdf_[l]);
 
-    return energy_[l] +
-           (1. / m) * (std::sqrt(pdf_[l] * pdf_[l] + 2. * m * (xi - cdf_[l])) -
-                       pdf_[l]);
+    return energy_[l] + (1. / m) * (std::sqrt(std::max(arg, 0.)) - pdf_[l]);
   }
 };
 

--- a/include/PapillonNDL/kalbach_table.hpp
+++ b/include/PapillonNDL/kalbach_table.hpp
@@ -250,10 +250,10 @@ class KalbachTable {
   }
 
   double linear_interp_energy(double xi, std::size_t l) const {
-    double m = (pdf_[l + 1] - pdf_[l]) / (energy_[l + 1] - energy_[l]);
-    return energy_[l] +
-           (1. / m) * (std::sqrt(pdf_[l] * pdf_[l] + 2. * m * (xi - cdf_[l])) -
-                       pdf_[l]);
+    const double m = (pdf_[l + 1] - pdf_[l]) / (energy_[l + 1] - energy_[l]);
+    const double arg = pdf_[l] * pdf_[l] + 2. * m * (xi - cdf_[l]);
+
+    return energy_[l] + (1. / m) * (std::sqrt(std::max(arg, 0.)) - pdf_[l]);
   }
 };
 

--- a/include/PapillonNDL/pctable.hpp
+++ b/include/PapillonNDL/pctable.hpp
@@ -146,10 +146,10 @@ class PCTable {
   }
 
   double linear_interp(double xi, std::size_t l) const {
-    double m = (pdf_[l + 1] - pdf_[l]) / (values_[l + 1] - values_[l]);
-    return values_[l] +
-           (1. / m) * (std::sqrt(pdf_[l] * pdf_[l] + 2. * m * (xi - cdf_[l])) -
-                       pdf_[l]);
+    const double m = (pdf_[l + 1] - pdf_[l]) / (values_[l + 1] - values_[l]);
+    const double arg = pdf_[l] * pdf_[l] + 2. * m * (xi - cdf_[l]);
+
+    return values_[l] + (1. / m) * (std::sqrt(std::max(arg, 0.)) - pdf_[l]);
   }
 };
 


### PR DESCRIPTION
I found a very rare bug (first observed in U235 MT91 in lib80x), where the sampling of the distribution was returning a `nan` energy. Upon further digging, I realized it was due to a negative argument in the square root function when linearly interpolating the PDF/CDF. This likely occurs due to an inadequate linearization/normalization of the two functions. While this was first noticed in `EnergyAngleTable`, it was also a possible problem in `KalbachTable` and `PCTable`. I have implemented the same fix in all three locations, where if the argument of the square root is negative, I set it to zero.