### PR TITLE
modified src/mcnp_library.cpp to properly read the directory entries

### DIFF
--- a/src/mcnp_library.cpp
+++ b/src/mcnp_library.cpp
@@ -114,6 +114,8 @@ MCNPLibrary::MCNPLibrary(const std::string& fname) : NDLibrary(fname) {
   }
   xsdir_buffer.erase(xsdir_buffer.begin(),
                      xsdir_buffer.begin() + match.position());
+  // concatenate a multi-line entry to a single line by removing "+\n"
+  xsdir_buffer = std::regex_replace(xsdir_buffer, std::regex(" \\+\\n"), " ");
   std::stringstream directory_stream(xsdir_buffer);
   std::string zaid_str;
   std::string awr_str;
@@ -130,19 +132,15 @@ MCNPLibrary::MCNPLibrary(const std::string& fname) : NDLibrary(fname) {
   std::string str, line;
   std::getline(directory_stream, line); // Get rid of 'directory' in stream
   while (directory_stream.eof() == false ) {
-    LINE_LOOP:
     std::getline(directory_stream, line); // get one line
     // remove leading, trailing and extra spaces in the line:
     // by Evgeny Karpov in https://shorturl.at/biH35
     line = std::regex_replace(line, std::regex("^ +| +$|( ) +"), "$1");
     std::stringstream linestream(line);
     //linestream.ignore();
-    while ( std::getline(linestream, str, ' ') ) { // split the line and store
-      if (str!="+" && line_buffer.size()<=11)      // each content if it's not
-        line_buffer.push_back(str);                // the continuation mark
-      else
-        goto LINE_LOOP;                            // goto the continued line
-    }
+    while ( std::getline(linestream, str, ' ') ) // split the line and store
+      if (line_buffer.size()<=11)                // each content upto 11th
+        line_buffer.push_back(str);              // in the vector 'line_buffer'
     zaid_str    = line_buffer[0];
     awr_str     = line_buffer[1];
     fname_str   = line_buffer[2];

--- a/src/mcnp_library.cpp
+++ b/src/mcnp_library.cpp
@@ -135,11 +135,14 @@ MCNPLibrary::MCNPLibrary(const std::string& fname) : NDLibrary(fname) {
   while (directory_stream.eof() == false) {
     // Get one line
     std::getline(directory_stream, line);
-    if (line=="") break;  // all the directory lines were already read
 
     // remove leading, trailing and extra spaces in the line:
     // by Evgeny Karpov in https://shorturl.at/biH35
     line = std::regex_replace(line, std::regex("^ +| +$|( ) +"), "$1");
+
+    // If the line is now empty, there were only white spaces.
+    // Try to read the next line if there are any.
+    if (line.empty()) continue;
 
     // split the line and store each component in line_buffer
     std::stringstream linestream(line);

--- a/src/mcnp_library.cpp
+++ b/src/mcnp_library.cpp
@@ -165,12 +165,23 @@ MCNPLibrary::MCNPLibrary(const std::string& fname) : NDLibrary(fname) {
     if (line_buffer.size() > 9) temp_str = line_buffer[9];
     if (line_buffer.size() > 10) ptable_str = line_buffer[10];
 
+    const char zaid_suffix = zaid_str.back();
+    if (zaid_suffix != 'c' && zaid_suffix != 't') {
+      // This isn't neutron data. Go to next entry
+      // clear the vector, empty strings
+      line_buffer.clear();
+      record_len_str.clear();
+      num_entries_str.clear();
+      temp_str.clear();
+      ptable_str.clear();
+      continue;
+    }
+
     // Convert entry components to needed data
     double temp = std::stod(temp_str) * MEV_TO_EV * EV_TO_K;
     std::filesystem::path ace_path = datapath / fname_str;
     const std::regex zaid_ext_regex("([.][\\w]{3,5})");
     ACE::Type ace_type = ACE::Type::ASCII;
-    const char zaid_suffix = zaid_str.back();
     if (ftype_str == "2") ace_type = ACE::Type::BINARY;
     zaid_str = std::regex_replace(zaid_str, zaid_ext_regex, "");
 

--- a/src/mcnp_library.cpp
+++ b/src/mcnp_library.cpp
@@ -135,6 +135,7 @@ MCNPLibrary::MCNPLibrary(const std::string& fname) : NDLibrary(fname) {
   while (directory_stream.eof() == false) {
     // Get one line
     std::getline(directory_stream, line);
+    if (line=="") break;  // all the directory lines were already read
 
     // remove leading, trailing and extra spaces in the line:
     // by Evgeny Karpov in https://shorturl.at/biH35


### PR DESCRIPTION
According to [an MCNP document](https://mcnp.lanl.gov/pdf_files/TechReport_2022_LANL_LA-UR-22-30006Rev.1_KuleszaAdamsEtAl.pdf ), the lines below "DIRECTORY" (case insensitive) in a "xsdir" file consist of "**seven- to eleven-entry** description of each table". The present implementation, however, seems to assume that eleven entries always exist, and therefore when it encounters a seven-entry line, it coredumps in e.g. trying to convert a string to double in mcnp_library.cpp:191

To properly read these variable-entry-number lines, a modification was made by utilizing std::getline(); the input stream is read line-by-line and then decomposed.

Tested with

- MCNP_DATA/xsdir
- MCNP_DATA/xsdir_mcnp5_endfb-7.0
- MCNP_DATA/xsdir_mcnp5_endfb-7.1
- MCNP_DATA/xsdir_mcnp6.1
- MCNP_DATA/xsdir_mcnp6.1_endfb-7.0
- MCNP_DATA/xsdir_mcnp6.1_endfb-7.1
of MCNP6.1 and
- PHITS331A/data/xsdir.jnd (JENDL-4)
of [PHITS](https://phits.jaea.go.jp/).